### PR TITLE
fix: Set initial release version in release-please-config.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "release-as": "0.1.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Set the initial release version to 0.1.0

#### What changes did you make? (Give an overview)

Used the `release-as` key in `release-please-config.json` to manually set the initial release version

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

We'll need to remove this later.

<!-- markdownlint-disable-file MD004 -->
