### PR TITLE
feat: Export internal constructs for other plugin authors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@
 //-----------------------------------------------------------------------------
 
 import { JSONLanguage } from "./languages/json-language.js";
+import { JSONSourceCode } from "./languages/json-source-code.js";
 import noDuplicateKeys from "./rules/no-duplicate-keys.js";
 import noEmptyKeys from "./rules/no-empty-keys.js";
 
@@ -43,3 +44,4 @@ Object.assign(plugin.configs, {
 });
 
 export default plugin;
+export { JSONLanguage, JSONSourceCode };

--- a/tests/package/exports.js
+++ b/tests/package/exports.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Tests for the package index's exports.
+ * @author Steve Dodier-Lazaro
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import * as exports from "../../src/index.js";
+import assert from "node:assert";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("Package exports", () => {
+	it("has the ESLint plugin as a default export", () => {
+		assert.deepStrictEqual(Object.keys(exports.default), [
+			"meta",
+			"languages",
+			"rules",
+			"configs",
+		]);
+	});
+
+	it("has a JSONLanguage export", () => {
+		assert.ok(exports.JSONLanguage);
+	});
+
+	it("has a JSONSourceCode export", () => {
+		assert.ok(exports.JSONSourceCode);
+	});
+});


### PR DESCRIPTION

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).


#### What is the purpose of this pull request?

Exports internal JSONLanguage and JSONSourceCode classes to allow further specialisation, so that plugins for JSON-based domain-specific languages can reuse that code without copying it.

#### What changes did you make? (Give an overview)

* Added named exports to the project index for `JSONLanguage` and `JSONSourceCode`

#### Related Issues

This was requested to the JSON plugin maintainer on [Discord](https://discord.com/channels/688543509199716507/1275121520162639913/1275464048095264862). Happy to open an issue for traceability if desired.

#### Is there anything you'd like reviewers to focus on?

* [x] Is `feat` okay as a commit type to use? Or do `refactor` or `chore` trigger patch releases?