### PR TITLE
fix: Don't require ESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,10 @@
   },
   "peerDependencies": {
     "eslint": "^9.6.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,13 +80,5 @@
   },
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-  },
-  "peerDependencies": {
-    "eslint": "^9.6.0"
-  },
-  "peerDependenciesMeta": {
-    "eslint": {
-      "optional": true
-    }
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Make ESLint an optional peer dependency.

#### What changes did you make? (Give an overview)

Added `peerDependenciesMeta` to `package.json` in order to set `eslint` as an optional peer dependency.

Practically speaking, the plugin doesn't require ESLint to be useful. We are using it in the Code Explorer without ESLint, where it's installation is causing npm errors because Code Explorer uses ESLint v8.x.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

It seems like we shouldn't block installation of this package even if ESLint isn't installed or ESLint v8.x is installed, but let me know if anyone has a different opinion. From what I can tell, this change won't have any noticeable effect to most users of this plugin.

<!-- markdownlint-disable-file MD004 -->
