### PR TITLE
feat: add rule no-unnormalized-keys

### DIFF
--- a/src/rules/no-unnormalized-keys.js
+++ b/src/rules/no-unnormalized-keys.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Rule to detect unnormalized keys in JSON.
+ * @author Bradley Meck Farias
+ */
+
+export default {
+	meta: {
+		type: "problem",
+
+		docs: {
+			description: "Disallow JSON keys that are not normalized",
+		},
+
+		messages: {
+			unnormalizedKey: "Unnormalized key found.",
+		},
+
+		schema: {
+			type: "array",
+			minItems: 0,
+			maxItems: 1,
+			items: {
+				enum: ["NFC", "NFD", "NFKC", "NFKD"],
+			},
+		},
+	},
+
+	create(context) {
+		const normalization = context.options.length
+			? s => s.normalize(context.options[0])
+			: s => s.normalize();
+		return {
+			Member(node) {
+				const key =
+					node.name.type === "String"
+						? node.name.value
+						: node.name.name;
+
+				if (normalization(key) !== key) {
+					context.report({
+						loc: node.name.loc,
+						messageId: "unnormalizedKey",
+					});
+				}
+			},
+		};
+	},
+};

--- a/tests/rules/no-unnormalized-keys.js
+++ b/tests/rules/no-unnormalized-keys.js
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Tests for no-empty-keys rule.
+ * @author Bradley Meck Farias
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import rule from "../../src/rules/no-unnormalized-keys.js";
+import json from "../../src/index.js";
+import { RuleTester } from "eslint";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	plugins: {
+		json,
+	},
+	language: "json/json",
+});
+
+const o = "\u1E9B\u0323";
+
+ruleTester.run("no-unnormalized-keys", rule, {
+	valid: [
+		`{"${o}":"NFC"}`,
+		{
+			code: `{"${o}":"NFC"}`,
+			options: ["NFC"],
+		},
+		{
+			code: `{"${o.normalize("NFD")}":"NFD"}`,
+			options: ["NFD"],
+		},
+		{
+			code: `{"${o.normalize("NFKC")}":"NFKC"}`,
+			options: ["NFKC"],
+		},
+		{
+			code: `{"${o.normalize("NFKD")}":"NFKD"}`,
+			options: ["NFKD"],
+		},
+	],
+	invalid: [
+		{
+			code: `{"${o.normalize("NFD")}":"NFD"}`,
+			errors: [
+				{
+					messageId: "unnormalizedKey",
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 7,
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To add a rule to check for JSON keys that are not normalized.

#### What changes did you make? (Give an overview)

Added a rule to check for JSON keys that are not normalized.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->
Fixes #32

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
Couldn't get options working on invalid test cases?
