### PR TITLE
test: Add `data` in tests for no-duplicate-keys rule

### DIFF
--- a/tests/rules/no-duplicate-keys.test.js
+++ b/tests/rules/no-duplicate-keys.test.js
@@ -41,6 +41,7 @@ ruleTester.run("no-duplicate-keys", rule, {
 			errors: [
 				{
 					messageId: "duplicateKey",
+					data: { key: "foo" },
 					line: 1,
 					column: 12,
 					endLine: 1,
@@ -58,6 +59,7 @@ ruleTester.run("no-duplicate-keys", rule, {
 			errors: [
 				{
 					messageId: "duplicateKey",
+					data: { key: "foo" },
 					line: 5,
 					column: 5,
 					endLine: 5,
@@ -71,6 +73,7 @@ ruleTester.run("no-duplicate-keys", rule, {
 			errors: [
 				{
 					messageId: "duplicateKey",
+					data: { key: "foo" },
 					line: 1,
 					column: 10,
 					endLine: 1,
@@ -89,6 +92,7 @@ ruleTester.run("no-duplicate-keys", rule, {
 			errors: [
 				{
 					messageId: "duplicateKey",
+					data: { key: "foo" },
 					line: 5,
 					column: 5,
 					endLine: 5,
@@ -102,6 +106,7 @@ ruleTester.run("no-duplicate-keys", rule, {
 			errors: [
 				{
 					messageId: "duplicateKey",
+					data: { key: "foo" },
 					line: 1,
 					column: 12,
 					endLine: 1,
@@ -120,6 +125,7 @@ ruleTester.run("no-duplicate-keys", rule, {
 			errors: [
 				{
 					messageId: "duplicateKey",
+					data: { key: "foo" },
 					line: 5,
 					column: 5,
 					endLine: 5,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Improves testing of the `no-duplicate-keys` rule.

#### What changes did you make? (Give an overview)

Added `data` property to invalid test cases.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
