### PR TITLE
feat: Add allowTrailingCommas option for JSONC

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ The Microsoft implementation of JSONC optionally allows for trailing commas in o
 import json from "@eslint/json";
 
 export default [
-
 	// lint JSONC files
 	{
 		files: ["**/*.jsonc"],
@@ -207,10 +206,9 @@ export default [
 		language: "json/jsonc",
 		languageOptions: {
 			allowTrailingCommas: true
-		}
+		},
 		...json.configs.recommended,
 	},
-
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,37 @@ In JSONC and JSON5 files, you can also use [rule configurations comments](https:
 
 Both line and block comments can be used for all kinds of configuration comments.
 
+## Allowing trailing commas in JSONC
+
+The Microsoft implementation of JSONC optionally allows for trailing commas in objects and arrays (files like `tsconfig.json` have this option enabled by default in Visual Studio Code). To enable trailing commas in JSONC files, use the `allowTrailingCommas` language option, as in this example:
+
+```js
+import json from "@eslint/json";
+
+export default [
+
+	// lint JSONC files
+	{
+		files: ["**/*.jsonc"],
+		language: "json/jsonc",
+		...json.configs.recommended,
+	},
+
+	// lint JSONC files and allow trailing commas
+	{
+		files: ["**/tsconfig.json", ".vscode/*.json"],
+		language: "json/jsonc",
+		languageOptions: {
+			allowTrailingCommas: true
+		}
+		...json.configs.recommended,
+	},
+
+];
+```
+
+**Note:** The `allowTrailingCommas` option is only valid for the `json/jsonc` language.
+
 ## Frequently Asked Questions
 
 ### How does this relate to `eslint-plugin-json` and `eslint-plugin-jsonc`?

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ export default [
 		files: ["**/tsconfig.json", ".vscode/*.json"],
 		language: "json/jsonc",
 		languageOptions: {
-			allowTrailingCommas: true
+			allowTrailingCommas: true,
 		},
 		...json.configs.recommended,
 	},

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@eslint/plugin-kit": "^0.2.0",
-    "@humanwhocodes/momoa": "^3.2.1"
+    "@humanwhocodes/momoa": "^3.3.0"
   },
   "devDependencies": {
     "@eslint/core": "^0.6.0",

--- a/src/languages/json-language.js
+++ b/src/languages/json-language.js
@@ -93,15 +93,15 @@ export class JSONLanguage {
 					"allowTrailingCommas must be a boolean if provided.",
 				);
 			}
-		}
 
-		// we know that allowTrailingCommas is a boolean here
+			// we know that allowTrailingCommas is a boolean here
 
-		// only allowed in JSONC mode
-		if (this.#mode !== "jsonc") {
-			throw new Error(
-				"allowTrailingCommas option is only available in JSONC.",
-			);
+			// only allowed in JSONC mode
+			if (this.#mode !== "jsonc") {
+				throw new Error(
+					"allowTrailingCommas option is only available in JSONC.",
+				);
+			}
 		}
 	}
 

--- a/tests/languages/json-language.test.js
+++ b/tests/languages/json-language.test.js
@@ -23,6 +23,48 @@ describe("JSONLanguage", () => {
 		});
 	});
 
+	describe("validateLanguageOptions()", () => {
+		it("should throw an error when allowTrailingCommas is not a boolean", () => {
+			const language = new JSONLanguage({
+				mode: "jsonc",
+				allowTrailingCommas: "true",
+			});
+			assert.throws(() => {
+				language.validateLanguageOptions({
+					allowTrailingCommas: "true",
+				});
+			}, /allowTrailingCommas/u);
+		});
+
+		it("should throw an error when allowTrailingCommas is a boolean in JSON mode", () => {
+			const language = new JSONLanguage({ mode: "json" });
+			assert.throws(() => {
+				language.validateLanguageOptions({ allowTrailingCommas: true });
+			}, /allowTrailingCommas/u);
+		});
+
+		it("should throw an error when allowTrailingCommas is a boolean in JSON5 mode", () => {
+			const language = new JSONLanguage({ mode: "json5" });
+			assert.throws(() => {
+				language.validateLanguageOptions({ allowTrailingCommas: true });
+			}, /allowTrailingCommas/u);
+		});
+
+		it("should not throw an error when allowTrailingCommas is a boolean in JSONC mode", () => {
+			const language = new JSONLanguage({ mode: "jsonc" });
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ allowTrailingCommas: true });
+			});
+		});
+
+		it("should not throw an error when allowTrailingCommas is not provided", () => {
+			const language = new JSONLanguage({ mode: "jsonc" });
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({});
+			});
+		});
+	});
+
 	describe("parse()", () => {
 		it("should not parse jsonc by default", () => {
 			const language = new JSONLanguage({ mode: "json" });
@@ -36,6 +78,49 @@ describe("JSONLanguage", () => {
 				result.errors[0].message,
 				"Unexpected character '/' found.",
 			);
+		});
+
+		it("should not parse trailing commas by default in json mode", () => {
+			const language = new JSONLanguage({ mode: "json" });
+			const result = language.parse({
+				body: '{\n"a": 1,\n}',
+				path: "test.json",
+			});
+
+			assert.strictEqual(result.ok, false);
+			assert.strictEqual(
+				result.errors[0].message,
+				"Unexpected token RBrace found.",
+			);
+		});
+
+		it("should not parse trailing commas by default in jsonc mode", () => {
+			const language = new JSONLanguage({ mode: "jsonc" });
+			const result = language.parse({
+				body: '{\n"a": 1,\n}',
+				path: "test.jsonc",
+			});
+
+			assert.strictEqual(result.ok, false);
+			assert.strictEqual(
+				result.errors[0].message,
+				"Unexpected token RBrace found.",
+			);
+		});
+
+		it("should parse trailing commas when enabled in jsonc mode", () => {
+			const language = new JSONLanguage({ mode: "jsonc" });
+			const result = language.parse(
+				{
+					body: '{\n"a": 1,\n}',
+					path: "test.jsonc",
+				},
+				{ languageOptions: { allowTrailingCommas: true } },
+			);
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.ast.type, "Document");
+			assert.strictEqual(result.ast.body.type, "Object");
 		});
 
 		it("should parse json by default", () => {

--- a/tests/languages/json-language.test.js
+++ b/tests/languages/json-language.test.js
@@ -63,6 +63,13 @@ describe("JSONLanguage", () => {
 				language.validateLanguageOptions({});
 			});
 		});
+
+		it("should not throw an error when allowTrailingCommas is not provided and other keys are present", () => {
+			const language = new JSONLanguage({ mode: "jsonc" });
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ foo: "bar" });
+			});
+		});
 	});
 
 	describe("parse()", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add support for trailing commas to the JSONC language.

#### What changes did you make? (Give an overview)

This pull request introduces support for allowing trailing commas in JSONC files and includes several updates to the codebase and documentation to reflect this new feature. The most important changes include adding a new option to enable trailing commas, updating the `JSONLanguage` class to validate and handle this option, and adding tests to ensure the feature works as expected.

### New Feature: Allow Trailing Commas in JSONC

* **README.md**: Added a section explaining how to enable trailing commas in JSONC files using the `allowTrailingCommas` language option. 

### Code Updates

* **`src/languages/json-language.js`**:
  * Added a new typedef for `JSONLanguageOptions` to include the `allowTrailingCommas` property. 
  * Updated the `validateLanguageOptions` method to check for the `allowTrailingCommas` option and ensure it is only used in JSONC mode.
  * Modified the `parse` method to accept and handle the `allowTrailingCommas` option. 

### Dependency Update

* **package.json**: Updated the `@humanwhocodes/momoa` dependency to version `^3.3.0`. 

### Tests

* **`tests/languages/json-language.test.js`**:
  * Added tests for the `validateLanguageOptions` method to ensure it correctly handles the `allowTrailingCommas` option. 
  * Added tests for the `parse` method to verify that trailing commas are correctly parsed or rejected based on the `allowTrailingCommas` option.

#### Related Issues

fixes #41

#### Is there anything you'd like reviewers to focus on?

Right now, `validateLanguageOptions()` throws an error when it finds `allowTrailingCommas` in JSON mode (where it cannot be enabled) and JSON5 mode (where it cannot be disabled). Would it be better to check the value of `allowTrailingCommas` before deciding to throw an error? So in JSON mode it would only throw if `allowTrailingCommas` is `true` and in JSON5 mode it would only throw an error if `allowTrailingCommas` is `false`? 

<!-- markdownlint-disable-file MD004 -->
