### PR TITLE
test: Add data into no-unsafe-values tests

### DIFF
--- a/tests/rules/no-unsafe-values.test.js
+++ b/tests/rules/no-unsafe-values.test.js
@@ -78,6 +78,7 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "loneSurrogate",
+					data: { surrogate: "\\ud83d" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -90,6 +91,7 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "loneSurrogate",
+					data: { surrogate: "\\udd25" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -102,6 +104,7 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "loneSurrogate",
+					data: { surrogate: "\\udd25" },
 					line: 1,
 					column: 1,
 					endLine: 1,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Update `no-unsafe-values` tests.

#### What changes did you make? (Give an overview)

Added `data` fields to all tests using `messageId` for lone surrogate errors.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
