### PR TITLE
test: Ensure all rules are exported

### DIFF
--- a/tests/package/exports.js
+++ b/tests/package/exports.js
@@ -38,11 +38,12 @@ describe("Package exports", () => {
 	it("has all available rules exported in the ESLint plugin", async () => {
 		const allRules = (await fs.readdir(rulesDir))
 			.filter(name => name.endsWith(".js"))
-			.map(name => name.slice(0, -".js".length));
+			.map(name => name.slice(0, -".js".length))
+			.sort();
 		const exportedRules = exports.default.rules;
 
 		assert.deepStrictEqual(
-			Object.keys(exportedRules),
+			Object.keys(exportedRules).sort(),
 			allRules,
 			"Expected all rules to be exported in the ESLint plugin (`plugin.rules` in `src/index.js`)",
 		);

--- a/tests/plugin/eslint.test.js
+++ b/tests/plugin/eslint.test.js
@@ -19,6 +19,25 @@ import dedent from "dedent";
 //-----------------------------------------------------------------------------
 
 describe("when the plugin is used with ESLint", () => {
+	describe("plugin configs", () => {
+		Object.keys(json.configs).forEach(configName => {
+			it(`Using "${configName}" config should not throw`, async () => {
+				const config = {
+					files: ["**/*.json"],
+					language: "json/json",
+					...json.configs[configName],
+				};
+
+				const eslint = new ESLint({
+					overrideConfigFile: true,
+					overrideConfig: config,
+				});
+
+				await eslint.lintText("{}", { filePath: "test.json" });
+			});
+		});
+	});
+
 	describe("config comments", () => {
 		["jsonc", "json5"].forEach(language => {
 			describe(`with ${language} language`, () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Ensures that all rules available in `src/rules` are exported in `plugin.rules`. Also adds a test for plugin configs that would fail if, for example, the config enables a non-existent rule.

#### What changes did you make? (Give an overview)

Added tests.

#### Related Issues

https://github.com/eslint/json/pull/51

#### Is there anything you'd like reviewers to focus on?

If this looks good, I'll add similar tests to `@eslint/markdown` and `@eslint/css`.

<!-- markdownlint-disable-file MD004 -->
