### PR TITLE
fix: expose `plugin.configs` in types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,19 +32,21 @@ const plugin = {
 		"no-empty-keys": noEmptyKeys,
 		"no-unsafe-values": noUnsafeValues,
 	},
-	configs: {},
-};
-
-Object.assign(plugin.configs, {
-	recommended: {
-		plugins: { json: plugin },
-		rules: {
-			"json/no-duplicate-keys": "error",
-			"json/no-empty-keys": "error",
-			"json/no-unsafe-values": "error",
+	configs: {
+		recommended: {
+			plugins: {
+				get json() {
+					return plugin;
+				},
+			},
+			rules: {
+				"json/no-duplicate-keys": "error",
+				"json/no-empty-keys": "error",
+				"json/no-unsafe-values": "error",
+			},
 		},
 	},
-});
+};
 
 export default plugin;
 export { JSONLanguage, JSONSourceCode };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Refactor code to fix the types

#### What changes did you make? (Give an overview)

This PR fixes the tsc-generated type of `plugin.configs`. It does so by moving the `configs` object into the `plugin` declaration rather that assigning its fields in a separate step. I'm using a getter to cyclically reference `plugin` as `plugin.configs.recommended.plugins.json`.

#### Related Issues

fixes #52

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

There are currently no type tests in this plugin. Shall we add some type tests as part of this PR?

<!-- markdownlint-disable-file MD004 -->
