### PR TITLE
chore: use eslint-plugin-eslint-plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@
 //-----------------------------------------------------------------------------
 
 import eslintConfigESLint from "eslint-config-eslint";
+import eslintPlugin from "eslint-plugin-eslint-plugin";
 import json from "./src/index.js";
 
 //-----------------------------------------------------------------------------
@@ -17,6 +18,11 @@ import json from "./src/index.js";
 const eslintPluginJSDoc = eslintConfigESLint.find(
 	config => config.plugins?.jsdoc,
 ).plugins.jsdoc;
+
+const eslintPluginRulesRecommendedConfig =
+	eslintPlugin.configs["flat/rules-recommended"];
+const eslintPluginTestsRecommendedConfig =
+	eslintPlugin.configs["flat/tests-recommended"];
 
 //-----------------------------------------------------------------------------
 // Configuration
@@ -65,6 +71,42 @@ export default [
 				before: "readonly",
 				after: "readonly",
 			},
+		},
+	},
+	{
+		files: ["src/rules/*.js"],
+		...eslintPluginRulesRecommendedConfig,
+		rules: {
+			...eslintPluginRulesRecommendedConfig.rules,
+			"eslint-plugin/require-meta-schema": "off", // `schema` defaults to []
+			"eslint-plugin/prefer-placeholders": "error",
+			"eslint-plugin/prefer-replace-text": "error",
+			"eslint-plugin/report-message-format": ["error", "[^a-z].*\\.$"],
+			"eslint-plugin/require-meta-docs-description": [
+				"error",
+				{ pattern: "^(Enforce|Require|Disallow) .+[^. ]$" },
+			],
+		},
+	},
+	{
+		files: ["tests/rules/*.test.js"],
+		...eslintPluginTestsRecommendedConfig,
+		rules: {
+			...eslintPluginTestsRecommendedConfig.rules,
+			"eslint-plugin/test-case-property-ordering": [
+				"error",
+				[
+					"name",
+					"filename",
+					"code",
+					"output",
+					"language",
+					"options",
+					"languageOptions",
+					"errors",
+				],
+			],
+			"eslint-plugin/test-case-shorthand-strings": "error",
 		},
 	},
 ];

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dedent": "^1.5.3",
     "eslint": "^9.11.1",
     "eslint-config-eslint": "^11.0.0",
+    "eslint-plugin-eslint-plugin": "^6.3.2",
     "got": "^14.4.2",
     "lint-staged": "^15.2.7",
     "mocha": "^10.4.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Enables `eslint-plugin-eslint-plugin` for linting rules and rule tests.

#### What changes did you make? (Give an overview)

Added `eslint-plugin-eslint-plugin` dev dependency and enabled rules in the eslint config.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

Config is the same as in eslint/eslint repo, except for:

* `eslint-plugin/require-meta-schema` is disabled. In ESLint v9, `schema` defaults to `[]`, so I think this rule isn't necessary, and we don't have `schema: []` in this plugin's rules.
* `eslint-plugin/require-meta-docs-url` is disabled as this plugin's rules don't have this property set (though it might be good to add URLs to rule docs on GitHub).
* `eslint-plugin/test-case-property-ordering` has `"language"` added.