### PR TITLE
chore: Post release announcements across services

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 #### Prerequisites checklist
 
--   [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).
+- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).
 
 <!--
     Please ensure your pull request is ready:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,18 +36,16 @@ jobs:
                   npx jsr publish
               if: ${{ steps.release.outputs.release_created }}
 
-            - name: Tweet release announcement
-              run: 'npx @humanwhocodes/tweet "eslint/json v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} has been released: ${{ steps.release.outputs.html_url }}"'
+            - name: Post release announcement
+              run: 'npx @humanwhocodes/crosspost -t -m -b "eslint/json v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} has been released: ${{ steps.release.outputs.html_url }}"'
               if: ${{ steps.release.outputs.release_created }}
               env:
-                  TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
-                  TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+                  TWITTER_API_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+                  TWITTER_API_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
                   TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
                   TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-
-            - name: Toot release announcement
-              run: 'npx @humanwhocodes/toot "eslint/json v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} has been released: ${{ steps.release.outputs.html_url }}"'
-              if: ${{ steps.release.outputs.release_created }}
-              env:
                   MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
                   MASTODON_HOST: ${{ secrets.MASTODON_HOST }}
+                  BLUESKY_IDENTIFIER: ${{ vars.BLUESKY_IDENTIFIER }}
+                  BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+                  BLUESKY_HOST: ${{ vars.BLUESKY_HOST }}

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ deno add @eslint/json
 
 This package exports these languages:
 
--   `"json/json"` is for regular JSON files
--   `"json/jsonc"` is for JSON files that support comments ([JSONC](https://github.com/microsoft/node-jsonc-parser)) such as those used for Visual Studio Code configuration files
--   `"json/json5"` is for [JSON5](https://json5.org) files
+- `"json/json"` is for regular JSON files
+- `"json/jsonc"` is for JSON files that support comments ([JSONC](https://github.com/microsoft/node-jsonc-parser)) such as those used for Visual Studio Code configuration files
+- `"json/json5"` is for [JSON5](https://json5.org) files
 
 Depending on which types of JSON files you'd like to lint, you can set up your `eslint.config.js` file to include just the files you'd like. Here's an example that lints JSON, JSONC, and JSON5 files:
 
@@ -152,10 +152,10 @@ export default [
 
 ## Rules
 
--   `no-duplicate-keys` - warns when there are two keys in an object with the same text.
--   `no-empty-keys` - warns when there is a key in an object that is an empty string or contains only whitespace (note: `package-lock.json` uses empty keys intentionally)
--   `no-unsafe-values` - warns on values that are unsafe for interchange, such as numbers outside safe range or lone surrogates.
--   `no-unnormalized-keys` - warns on keys containing [unnormalized characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#description). You can optionally specify the normalization form via `{ form: "form_name" }`, where `form_name` can be any of `"NFC"`, `"NFD"`, `"NFKC"`, or `"NFKD"`.
+- `no-duplicate-keys` - warns when there are two keys in an object with the same text.
+- `no-empty-keys` - warns when there is a key in an object that is an empty string or contains only whitespace (note: `package-lock.json` uses empty keys intentionally)
+- `no-unsafe-values` - warns on values that are unsafe for interchange, such as numbers outside safe range or lone surrogates.
+- `no-unnormalized-keys` - warns on keys containing [unnormalized characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#description). You can optionally specify the normalization form via `{ form: "form_name" }`, where `form_name` can be any of `"NFC"`, `"NFD"`, `"NFKC"`, or `"NFKD"`.
 
 ## Configuration Comments
 
@@ -222,8 +222,8 @@ export default [
 
 This plugin implements JSON parsing for ESLint using the language plugins API, which is the official way of supporting non-JavaScript languages in ESLint. This differs from the other plugins:
 
--   `eslint-plugin-json` uses a processor to parse the JSON, meaning it doesn't create an AST and you can't write custom rules for it.
--   `eslint-plugin-jsonc` uses a parser that still goes through the JavaScript linting functionality and requires several rules to disallow valid JavaScript syntax that is invalid in JSON.
+- `eslint-plugin-json` uses a processor to parse the JSON, meaning it doesn't create an AST and you can't write custom rules for it.
+- `eslint-plugin-jsonc` uses a parser that still goes through the JavaScript linting functionality and requires several rules to disallow valid JavaScript syntax that is invalid in JSON.
 
 As such, this plugin is more robust and faster than the others. You can write your own custom rules when using the languages in this plugin, too.
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "got": "^14.4.2",
     "lint-staged": "^15.2.7",
     "mocha": "^10.4.0",
-    "prettier": "^3.3.2",
+    "prettier": "^3.4.1",
     "rollup": "^4.16.2",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^5.4.5",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Update how we post release announcements. This will now post to Twitter, Mastodon, and Bluesky.

#### What changes did you make? (Give an overview)

- Switched to use `@humanwhocodes/crosspost` to post across multiple services in one step
- Added organization secrets and variables for the BlueSky info

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

I've tested this on my own project and it worked, but want to just try this out on one of our repos to verify that everything is configured correctly before rolling out across the org.


<!-- markdownlint-disable-file MD004 -->
