### PR TITLE
test: Matching escaped and unescaped keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@eslint/plugin-kit": "^0.2.3",
-    "@humanwhocodes/momoa": "^3.3.3"
+    "@humanwhocodes/momoa": "^3.3.4"
   },
   "devDependencies": {
     "@eslint/core": "^0.6.0",

--- a/tests/rules/no-duplicate-keys.test.js
+++ b/tests/rules/no-duplicate-keys.test.js
@@ -133,5 +133,61 @@ ruleTester.run("no-duplicate-keys", rule, {
 				},
 			],
 		},
+		{
+			code: '{"f\\u006fot": 1, "fo\\u006ft": 2}',
+			errors: [
+				{
+					messageId: "duplicateKey",
+					data: { key: "foot" },
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: '{"f\\u006fot": 1, "fo\\u006ft": 2}',
+			language: "json/jsonc",
+			errors: [
+				{
+					messageId: "duplicateKey",
+					data: { key: "foot" },
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: '{"f\\u006fot": 1, "fo\\u006ft": 2}',
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "duplicateKey",
+					data: { key: "foot" },
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		// See: https://github.com/humanwhocodes/momoa/issues/164
+		// {
+		// 	code: '{f\\u006fot: 1, fo\\u006ft: 2}',
+		// 	language: "json/json5",
+		// 	errors: [
+		// 		{
+		// 			messageId: "duplicateKey",
+		// 			data: { key: "foot" },
+		// 			line: 1,
+		// 			column: 18,
+		// 			endLine: 1,
+		// 			endColumn: 29,
+		// 		},
+		// 	],
+		// },
 	],
 });

--- a/tests/rules/no-duplicate-keys.test.js
+++ b/tests/rules/no-duplicate-keys.test.js
@@ -174,20 +174,19 @@ ruleTester.run("no-duplicate-keys", rule, {
 				},
 			],
 		},
-		// See: https://github.com/humanwhocodes/momoa/issues/164
-		// {
-		// 	code: '{f\\u006fot: 1, fo\\u006ft: 2}',
-		// 	language: "json/json5",
-		// 	errors: [
-		// 		{
-		// 			messageId: "duplicateKey",
-		// 			data: { key: "foot" },
-		// 			line: 1,
-		// 			column: 18,
-		// 			endLine: 1,
-		// 			endColumn: 29,
-		// 		},
-		// 	],
-		// },
+		{
+			code: '{f\\u006fot: 1, fo\\u006ft: 2}',
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "duplicateKey",
+					data: { key: "foot" },
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 25,
+				},
+			],
+		},
 	],
 });

--- a/tests/rules/no-duplicate-keys.test.js
+++ b/tests/rules/no-duplicate-keys.test.js
@@ -175,7 +175,7 @@ ruleTester.run("no-duplicate-keys", rule, {
 			],
 		},
 		{
-			code: '{f\\u006fot: 1, fo\\u006ft: 2}',
+			code: "{f\\u006fot: 1, fo\\u006ft: 2}",
 			language: "json/json5",
 			errors: [
 				{


### PR DESCRIPTION

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Ensure that escaped and unescaped keys of objects that evaluate to the same string still trigger rules that prevent duplicate keys.

#### What changes did you make? (Give an overview)

Added tests with `o` replaced with `\\u006f` in strategic places.  Note that the double-backslash is necessary so that the JSON parser is processing the backslash, not the JS parser running the tests.

#### Related Issues

Refs #68

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

Note that this is affected by
https://github.com/humanwhocodes/momoa/issues/164
in the sense that in JSON5 mode, unquoted escaped
keys are not yet unescaped in the same was as
all other keys, and will not trigger this lint
yet.  When the momoa issue is fixed, released, and we have updated to that version, uncomment the
last test in no-duplicate-keys.test.js.

Suggest that we create a separate issue in this
repo to track that change.