### PR TITLE
feat: Catch more unsafe numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,11 @@ export default [
 - `no-duplicate-keys` - warns when there are two keys in an object with the same text.
 - `no-empty-keys` - warns when there is a key in an object that is an empty string or contains only whitespace (note: `package-lock.json` uses empty keys intentionally)
 - `no-unsafe-values` - warns on values that are unsafe for interchange, such
-  as strings with unmatched surrogates, numbers that evaluate to Infinity,
-  numbers that evaluate to zero unintentionally, numbers that look like
-  integers but are too large, and subnormal numbers (see:
-  https://en.wikipedia.org/wiki/Subnormal_number).
+  as strings with unmatched
+  [surrogates](https://en.wikipedia.org/wiki/UTF-16), numbers that evaluate to
+  Infinity, numbers that evaluate to zero unintentionally, numbers that look
+  like integers but are too large, and
+  [subnormal numbers](https://en.wikipedia.org/wiki/Subnormal_number).
 - `no-unnormalized-keys` - warns on keys containing [unnormalized characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#description). You can optionally specify the normalization form via `{ form: "form_name" }`, where `form_name` can be any of `"NFC"`, `"NFD"`, `"NFKC"`, or `"NFKD"`.
 
 ## Configuration Comments

--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ export default [
 
 - `no-duplicate-keys` - warns when there are two keys in an object with the same text.
 - `no-empty-keys` - warns when there is a key in an object that is an empty string or contains only whitespace (note: `package-lock.json` uses empty keys intentionally)
-- `no-unsafe-values` - warns on values that are unsafe for interchange, such as numbers outside safe range or lone surrogates.
+- `no-unsafe-values` - warns on values that are unsafe for interchange, such
+  as strings with unmatched surrogates, numbers that evaluate to Infinity,
+  numbers that evaluate to zero unintentionally, numbers that look like
+  integers but are too large, and subnormal numbers (see:
+  https://en.wikipedia.org/wiki/Subnormal_number).
 - `no-unnormalized-keys` - warns on keys containing [unnormalized characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#description). You can optionally specify the normalization form via `{ form: "form_name" }`, where `form_name` can be any of `"NFC"`, `"NFD"`, `"NFKC"`, or `"NFKD"`.
 
 ## Configuration Comments

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -15,7 +15,7 @@ export default {
 
 		docs: {
 			description:
-				"Disallow JSON values that are unsafe for interchange.  This includes strings with unmatched surrogates, numbers that evaluate to Infinity, numbers that evaluate to zero unintentionally, numbers that look like integers but they are too large, and subnormal numbers (see: https://en.wikipedia.org/wiki/Subnormal_number)",
+				"Disallow JSON values that are unsafe for interchange",
 		},
 
 		messages: {

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -14,8 +14,7 @@ export default {
 		type: /** @type {const} */ ("problem"),
 
 		docs: {
-			description:
-				"Disallow JSON values that are unsafe for interchange",
+			description: "Disallow JSON values that are unsafe for interchange",
 		},
 
 		messages: {

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -48,9 +48,9 @@ export default {
 						const match = value.match(NUMBER);
 						// assert(match, "If the regex is right, match is always truthy")
 
-						// If any part of the number other than the  has a non-zero digit
-						// in it, this number was not intended to be evaluated down to a
-						// zero.
+						// If any part of the number other than the exponent has a
+						// non-zero digit in it, this number was not intended to be
+						// evaluated down to a zero.
 						if (
 							NON_ZERO.test(match.groups.int) ||
 							NON_ZERO.test(match.groups.frac)
@@ -61,7 +61,7 @@ export default {
 								data: { value },
 							});
 						}
-					} else if (!value.match(/[.e]/iu)) {
+					} else if (!/[.e]/iu.test(value)) {
 						// Intended to be an integer
 						if (
 							node.value > Number.MAX_SAFE_INTEGER ||

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -3,9 +3,11 @@
  * @author Bradley Meck Farias
  */
 
-// These numbers evaluated to zero unexpectedly.  If the group's digits
-// are all zero, that's fine.
-const SMALL_NUMBERS = [/\.(\d+)/u, /((?:\d+\.)?\d+)e/iu];
+// RFC 8259's `number` production, as a regex.  Capture the integer part
+// and the fractional part.
+const NUMBER =
+	/^-?(?<int>0|([1-9][0-9]*))(?:\.(?<frac>[0-9]+))?(?:[eE][+-]?[0-9]+)?$/u;
+const NON_ZERO = /[1-9]/u;
 
 export default {
 	meta: {
@@ -18,7 +20,10 @@ export default {
 		messages: {
 			unsafeNumber: "Number outside safe range found.",
 			unsafeInteger: "Integer outside safe range found.",
-			subnormal: "Subnormal numbers are outside the safe range.",
+			unsafeZero:
+				"This number will evaluate to zero, which is unintended.",
+			subnormal:
+				"Subnormal numbers (see https://en.wikipedia.org/wiki/Subnormal_number) are outside the safe range: '{{ value }}'.",
 			loneSurrogate: "Lone surrogate '{{ surrogate }}' found.",
 		},
 	},
@@ -33,20 +38,26 @@ export default {
 					});
 				} else {
 					const txt = context.sourceCode.getText(node);
+
+					// Also matches -0, intentionally
 					if (node.value === 0) {
-						// If the value has been rounded down to 0, but there was some fraction
-						// or non-zero part before an e-, this is a very small number that doesn't
-						// fit inside an f64.
-						for (const r of SMALL_NUMBERS) {
-							const m = txt.match(r);
-							// If the digits are all 0, it's ok.
-							if (m?.[1]?.match(/[1-9]/u)) {
-								context.report({
-									loc: node.loc,
-									messageId: "unsafeNumber",
-								});
-								break;
-							}
+						// If the value has been rounded down to 0, but there was some
+						// fraction or non-zero part before the e-, this is a very small
+						// number that doesn't fit inside an f64.
+						const match = txt.match(NUMBER);
+						// assert(match, "If the regex is right, match is always truthy")
+
+						// If any part of the number other than the  has a non-zero digit
+						// in it, this number was not intended to be evaluated down to a
+						// zero.
+						if (
+							NON_ZERO.test(match.groups.int) ||
+							NON_ZERO.test(match.groups.frac)
+						) {
+							context.report({
+								loc: node.loc,
+								messageId: "unsafeZero",
+							});
 						}
 					} else if (!txt.match(/[.e]/iu)) {
 						// Intended to be an integer
@@ -61,15 +72,17 @@ export default {
 						}
 					} else {
 						// Floating point.  Check for subnormal.
-						const ab = new ArrayBuffer(8);
-						const dv = new DataView(ab);
-						dv.setFloat64(0, node.value, false);
-						const bi = dv.getBigUint64(0, false);
+						const buffer = new ArrayBuffer(8);
+						const view = new DataView(buffer);
+						view.setFloat64(0, node.value, false);
+						const asBigInt = view.getBigUint64(0, false);
 						// Subnormals have an 11-bit exponent of 0 and a non-zero mantissa.
-						if ((bi & 0x7ff0000000000000n) === 0n) {
+						if ((asBigInt & 0x7ff0000000000000n) === 0n) {
 							context.report({
 								loc: node.loc,
 								messageId: "subnormal",
+								// Value included so that it's seen in scientific notation
+								data: node,
 							});
 						}
 					}

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -14,7 +14,8 @@ export default {
 		type: /** @type {const} */ ("problem"),
 
 		docs: {
-			description: "Disallow JSON values that are unsafe for interchange",
+			description:
+				"Disallow JSON values that are unsafe for interchange.  This includes strings with unmatched surrogates, numbers that evaluate to Infinity, numbers that evaluate to zero unintentionally, numbers that look like integers but they are too large, and subnormal numbers (see: https://en.wikipedia.org/wiki/Subnormal_number)",
 		},
 
 		messages: {
@@ -23,7 +24,7 @@ export default {
 			unsafeZero:
 				"This number will evaluate to zero, which is unintended.",
 			subnormal:
-				"Subnormal numbers (see https://en.wikipedia.org/wiki/Subnormal_number) are outside the safe range: '{{ value }}'.",
+				"Unexpected subnormal number '{{ value }}' found.  Subnormal numbers are outside the safe range.",
 			loneSurrogate: "Lone surrogate '{{ surrogate }}' found.",
 		},
 	},

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -3,6 +3,10 @@
  * @author Bradley Meck Farias
  */
 
+// These numbers evaluated to zero unexpectedly.  If the group's digits
+// are all zero, that's fine.
+const SMALL_NUMBERS = [/\.(\d+)/u, /((?:\d+\.)?\d+)e/iu];
+
 export default {
 	meta: {
 		type: /** @type {const} */ ("problem"),
@@ -13,6 +17,8 @@ export default {
 
 		messages: {
 			unsafeNumber: "Number outside safe range found.",
+			unsafeInteger: "Integer outside safe range found.",
+			subnormal: "Subnormal numbers are outside the safe range.",
 			loneSurrogate: "Lone surrogate '{{ surrogate }}' found.",
 		},
 	},
@@ -25,6 +31,48 @@ export default {
 						loc: node.loc,
 						messageId: "unsafeNumber",
 					});
+				} else {
+					const txt = context.sourceCode.getText(node);
+					if (node.value === 0) {
+						// If the value has been rounded down to 0, but there was some fraction
+						// or non-zero part before an e-, this is a very small number that doesn't
+						// fit inside an f64.
+						for (const r of SMALL_NUMBERS) {
+							const m = txt.match(r);
+							// If the digits are all 0, it's ok.
+							if (m?.[1]?.match(/[1-9]/u)) {
+								context.report({
+									loc: node.loc,
+									messageId: "unsafeNumber",
+								});
+								break;
+							}
+						}
+					} else if (!txt.match(/[.e]/iu)) {
+						// Intended to be an integer
+						if (
+							node.value > Number.MAX_SAFE_INTEGER ||
+							node.value < Number.MIN_SAFE_INTEGER
+						) {
+							context.report({
+								loc: node.loc,
+								messageId: "unsafeInteger",
+							});
+						}
+					} else {
+						// Floating point.  Check for subnormal.
+						const ab = new ArrayBuffer(8);
+						const dv = new DataView(ab);
+						dv.setFloat64(0, node.value, false);
+						const bi = dv.getBigUint64(0, false);
+						// Subnormals have an 11-bit exponent of 0 and a non-zero mantissa.
+						if ((bi & 0x7ff0000000000000n) === 0n) {
+							context.report({
+								loc: node.loc,
+								messageId: "subnormal",
+							});
+						}
+					}
 				}
 			},
 			String(node) {

--- a/tests/rules/no-unsafe-values.test.js
+++ b/tests/rules/no-unsafe-values.test.js
@@ -35,6 +35,9 @@ ruleTester.run("no-unsafe-values", rule, {
 		},
 		'"🔥"',
 		'"\\ud83d\\udd25"',
+		"0.00000",
+		"0e0000000",
+		"0.00000e0000",
 	],
 	invalid: [
 		{
@@ -135,7 +138,7 @@ ruleTester.run("no-unsafe-values", rule, {
 			code: "1e-400",
 			errors: [
 				{
-					messageId: "unsafeNumber",
+					messageId: "unsafeZero",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -147,7 +150,7 @@ ruleTester.run("no-unsafe-values", rule, {
 			code: "-1e-400",
 			errors: [
 				{
-					messageId: "unsafeNumber",
+					messageId: "unsafeZero",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -159,7 +162,7 @@ ruleTester.run("no-unsafe-values", rule, {
 			code: "0.01e-400",
 			errors: [
 				{
-					messageId: "unsafeNumber",
+					messageId: "unsafeZero",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -171,7 +174,7 @@ ruleTester.run("no-unsafe-values", rule, {
 			code: "-10.2e-402",
 			errors: [
 				{
-					messageId: "unsafeNumber",
+					messageId: "unsafeZero",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -183,7 +186,7 @@ ruleTester.run("no-unsafe-values", rule, {
 			code: `0.${"0".repeat(400)}1`,
 			errors: [
 				{
-					messageId: "unsafeNumber",
+					messageId: "unsafeZero",
 					line: 1,
 					column: 1,
 					endLine: 1,

--- a/tests/rules/no-unsafe-values.test.js
+++ b/tests/rules/no-unsafe-values.test.js
@@ -45,6 +45,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeNumber",
+					data: {
+						value: "2e308",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -57,6 +60,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeNumber",
+					data: {
+						value: "-2e308",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -139,6 +145,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeZero",
+					data: {
+						value: "1e-400",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -151,6 +160,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeZero",
+					data: {
+						value: "-1e-400",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -163,6 +175,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeZero",
+					data: {
+						value: "0.01e-400",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -175,6 +190,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeZero",
+					data: {
+						value: "-10.2e-402",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -187,6 +205,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeZero",
+					data: {
+						value: `0.${"0".repeat(400)}1`,
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -199,6 +220,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeInteger",
+					data: {
+						value: "9007199254740992",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -211,6 +235,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "unsafeInteger",
+					data: {
+						value: "-9007199254740992",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -223,6 +250,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "subnormal",
+					data: {
+						value: "2.225073858507201e-308",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -235,6 +265,9 @@ ruleTester.run("no-unsafe-values", rule, {
 			errors: [
 				{
 					messageId: "subnormal",
+					data: {
+						value: "-2.225073858507201e-308",
+					},
 					line: 1,
 					column: 1,
 					endLine: 1,

--- a/tests/rules/no-unsafe-values.test.js
+++ b/tests/rules/no-unsafe-values.test.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Tests for no-empty-keys rule.
+ * @fileoverview Tests for no-unsafe-values rule.
  * @author Bradley Meck Farias
  */
 

--- a/tests/rules/no-unsafe-values.test.js
+++ b/tests/rules/no-unsafe-values.test.js
@@ -131,5 +131,113 @@ ruleTester.run("no-unsafe-values", rule, {
 				},
 			],
 		},
+		{
+			code: "1e-400",
+			errors: [
+				{
+					messageId: "unsafeNumber",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: "-1e-400",
+			errors: [
+				{
+					messageId: "unsafeNumber",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 8,
+				},
+			],
+		},
+		{
+			code: "0.01e-400",
+			errors: [
+				{
+					messageId: "unsafeNumber",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 10,
+				},
+			],
+		},
+		{
+			code: "-10.2e-402",
+			errors: [
+				{
+					messageId: "unsafeNumber",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 11,
+				},
+			],
+		},
+		{
+			code: `0.${"0".repeat(400)}1`,
+			errors: [
+				{
+					messageId: "unsafeNumber",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 404,
+				},
+			],
+		},
+		{
+			code: "9007199254740992",
+			errors: [
+				{
+					messageId: "unsafeInteger",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: "-9007199254740992",
+			errors: [
+				{
+					messageId: "unsafeInteger",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 18,
+				},
+			],
+		},
+		{
+			code: "2.2250738585072009e-308",
+			errors: [
+				{
+					messageId: "subnormal",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 24,
+				},
+			],
+		},
+		{
+			code: "-2.2250738585072009e-308",
+			errors: [
+				{
+					messageId: "subnormal",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 25,
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Catch subnormals, numbers that are flushed to zero,
and overly-large integers in no-unsafe-values.

#### What changes did you make? (Give an overview)

Added three numeric cases to no-unsafe-values.js:
- Flushed to zero: the parsed value is zero, but the original text implies that zero was not intended.  Example: `1e-400`
- Overly-large integers: the original text looks like an integer (no decimal point or exponent), but the value is outside the range `[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]`.  `Example: 9007199254740992`
- Subnormals: these are numbers that have reduced precision in an IEEE-754 f64.  Example: `2.2250738585072009e-308`

#### Related Issues

Refs #68

#### Is there anything you'd like reviewers to focus on?

Please double-check my error messages for your preferences.