### PR TITLE
fix: make types usable in CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@eslint/plugin-kit": "^0.2.3",
+    "@eslint/core": "^0.10.0",
+    "@eslint/plugin-kit": "^0.2.5",
     "@humanwhocodes/momoa": "^3.3.4"
   },
   "devDependencies": {
-    "@eslint/core": "^0.6.0",
     "@types/eslint": "^8.56.10",
     "c8": "^9.1.0",
     "dedent": "^1.5.3",

--- a/tests/types/cjs-import.test.cts
+++ b/tests/types/cjs-import.test.cts
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview CommonJS type import test for ESLint JSON Language Plugin.
+ * @author Francesco Trotta
+ */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import "@eslint/json";

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "../..",
     "strict": true
   },
-  "files": ["../../dist/esm/index.d.ts", "types.test.ts"]
+  "files": [],
+  "include": [".", "../../dist"]
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Similar to eslint/rewrite#143, this PR ensures that the `@eslint/json` types can be imported from a CommonJS module when [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) is one of `'node16'` or `'nodenext'`. This is currently not possible because of an issue with the types in `@eslint/plugin-kit` that has been fixed in the latest version `v0.2.5`.

#### What changes did you make? (Give an overview)

* Updated dependency `@eslint/plugin-kit` to version spec `"^0.2.5"`.
* Made `@eslint/core` a runtime dependency of this package.
* Added tests to ensure that `@eslint/json` can be imported from a `.cts` file.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

refs eslint/rewrite#143.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
