### PR TITLE
fix: Update types and apply to all rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@eslint/core": "^0.12.0",
     "@eslint/plugin-kit": "^0.2.7",
     "@humanwhocodes/momoa": "^3.3.4",
-    "momoa": "^1.2.0",
     "natural-compare": "^1.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@eslint/core": "^0.12.0",
     "@eslint/plugin-kit": "^0.2.7",
     "@humanwhocodes/momoa": "^3.3.4",
+    "momoa": "^1.2.0",
     "natural-compare": "^1.4.0"
   },
   "devDependencies": {

--- a/src/rules/no-duplicate-keys.js
+++ b/src/rules/no-duplicate-keys.js
@@ -16,7 +16,7 @@
 //-----------------------------------------------------------------------------
 
 /** @type {NoDuplicateKeysRuleDefinition} */
-export default {
+const rule = {
 	meta: {
 		type: "problem",
 
@@ -66,3 +66,5 @@ export default {
 		};
 	},
 };
+
+export default rule;

--- a/src/rules/no-empty-keys.js
+++ b/src/rules/no-empty-keys.js
@@ -15,7 +15,7 @@
 //-----------------------------------------------------------------------------
 
 /** @type {NoEmptyKeysRuleDefinition} */
-export default {
+const rule = {
 	meta: {
 		type: "problem",
 
@@ -46,3 +46,5 @@ export default {
 		};
 	},
 };
+
+export default rule;

--- a/src/rules/no-unnormalized-keys.js
+++ b/src/rules/no-unnormalized-keys.js
@@ -3,7 +3,19 @@
  * @author Bradley Meck Farias
  */
 
-export default {
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/** @typedef {"unnormalizedKey"} NoUnnormalizedKeysMessageIds */
+/** @typedef {import("../types.ts").JSONRuleDefinition<[], NoUnnormalizedKeysMessageIds>} NoUnnormalizedKeysRuleDefinition */
+
+//-----------------------------------------------------------------------------
+// Rule Definition
+//-----------------------------------------------------------------------------
+
+/** @type {NoUnnormalizedKeysRuleDefinition} */
+const rule = {
 	meta: {
 		type: /** @type {const} */ ("problem"),
 
@@ -29,9 +41,9 @@ export default {
 	},
 
 	create(context) {
-		const normalization = context.options.length
-			? text => text.normalize(context.options[0].form)
-			: text => text.normalize();
+		const options = /** @type {{form:string}[]} */ (context.options);
+		const form = options.length ? options[0].form : undefined;
+
 		return {
 			Member(node) {
 				const key =
@@ -39,7 +51,7 @@ export default {
 						? node.name.value
 						: node.name.name;
 
-				if (normalization(key) !== key) {
+				if (key.normalize(form) !== key) {
 					context.report({
 						loc: node.name.loc,
 						messageId: "unnormalizedKey",
@@ -52,3 +64,5 @@ export default {
 		};
 	},
 };
+
+export default rule;

--- a/src/rules/no-unnormalized-keys.js
+++ b/src/rules/no-unnormalized-keys.js
@@ -8,7 +8,7 @@
 //-----------------------------------------------------------------------------
 
 /** @typedef {"unnormalizedKey"} NoUnnormalizedKeysMessageIds */
-/** @typedef {import("../types.ts").JSONRuleDefinition<[], NoUnnormalizedKeysMessageIds>} NoUnnormalizedKeysRuleDefinition */
+/** @typedef {import("../types.ts").JSONRuleDefinition<[{form:string}], NoUnnormalizedKeysMessageIds>} NoUnnormalizedKeysRuleDefinition */
 
 //-----------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +17,7 @@
 /** @type {NoUnnormalizedKeysRuleDefinition} */
 const rule = {
 	meta: {
-		type: /** @type {const} */ ("problem"),
+		type: "problem",
 
 		docs: {
 			description: "Disallow JSON keys that are not normalized",
@@ -41,8 +41,9 @@ const rule = {
 	},
 
 	create(context) {
-		const options = /** @type {{form:string}[]} */ (context.options);
-		const form = options.length ? options[0].form : undefined;
+		const form = context.options.length
+			? context.options[0].form
+			: undefined;
 
 		return {
 			Member(node) {

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -30,7 +30,7 @@ const NON_ZERO = /[1-9]/u;
 //-----------------------------------------------------------------------------
 
 /** @type {NoUnsafeValuesRuleDefinition} */
-export default {
+const rule = {
 	meta: {
 		type: "problem",
 
@@ -145,3 +145,5 @@ export default {
 		};
 	},
 };
+
+export default rule;

--- a/src/rules/sort-keys.js
+++ b/src/rules/sort-keys.js
@@ -15,9 +15,7 @@ import naturalCompare from "natural-compare";
 //-----------------------------------------------------------------------------
 
 /** @typedef {"sortKeys"} SortKeysMessageIds */
-/** @typedef {import("../types.ts").JSONRuleDefinition<[], SortKeysMessageIds>} SortKeysRuleDefinition */
-/** @typedef {(a:string,b:string) => boolean} Comparator */
-/** @typedef {import("@humanwhocodes/momoa").MemberNode} MemberNode */
+
 /**
  * @typedef {Object} SortOptions
  * @property {boolean} caseSensitive
@@ -25,8 +23,12 @@ import naturalCompare from "natural-compare";
  * @property {number} minKeys
  * @property {boolean} allowLineSeparatedGroups
  */
+
 /** @typedef {"asc"|"desc"} SortDirection */
 /** @typedef {[SortDirection, SortOptions]} SortKeysRuleOptions */
+/** @typedef {import("../types.ts").JSONRuleDefinition<SortKeysRuleOptions, SortKeysMessageIds>} SortKeysRuleDefinition */
+/** @typedef {(a:string,b:string) => boolean} Comparator */
+/** @typedef {import("@humanwhocodes/momoa").MemberNode} MemberNode */
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -139,11 +141,10 @@ const rule = {
 	},
 
 	create(context) {
-		const options = /** @type {Array<string|Object>} */ (context.options);
 		const [
 			directionShort,
 			{ allowLineSeparatedGroups, caseSensitive, natural, minKeys },
-		] = /** @type { SortKeysRuleOptions} */ (options);
+		] = context.options;
 
 		const direction = directionShort === "asc" ? "ascending" : "descending";
 		const sortName = natural ? "natural" : "alphanumeric";

--- a/src/rules/sort-keys.js
+++ b/src/rules/sort-keys.js
@@ -1,48 +1,97 @@
 /**
- * @fileoverview Rule to require JSON object keys to be sorted. Copied largely from https://github.com/eslint/eslint/blob/main/lib/rules/sort-keys.js
+ * @fileoverview Rule to require JSON object keys to be sorted.
+ * Copied largely from https://github.com/eslint/eslint/blob/main/lib/rules/sort-keys.js
  * @author Robin Thomas
  */
 
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
 import naturalCompare from "natural-compare";
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/** @typedef {"sortKeys"} SortKeysMessageIds */
+/** @typedef {import("../types.ts").JSONRuleDefinition<[], SortKeysMessageIds>} SortKeysRuleDefinition */
+/** @typedef {(a:string,b:string) => boolean} Comparator */
+/** @typedef {import("@humanwhocodes/momoa").MemberNode} MemberNode */
+/**
+ * @typedef {Object} SortOptions
+ * @property {boolean} caseSensitive
+ * @property {boolean} natural
+ * @property {number} minKeys
+ * @property {boolean} allowLineSeparatedGroups
+ */
+/** @typedef {"asc"|"desc"} SortDirection */
+/** @typedef {[SortDirection, SortOptions]} SortKeysRuleOptions */
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
 
 const hasNonWhitespace = /\S/u;
 
 const comparators = {
 	ascending: {
 		alphanumeric: {
+			/** @type {Comparator} */
 			sensitive: (a, b) => a <= b,
+
+			/** @type {Comparator} */
 			insensitive: (a, b) => a.toLowerCase() <= b.toLowerCase(),
 		},
 		natural: {
+			/** @type {Comparator} */
 			sensitive: (a, b) => naturalCompare(a, b) <= 0,
+
+			/** @type {Comparator} */
 			insensitive: (a, b) =>
 				naturalCompare(a.toLowerCase(), b.toLowerCase()) <= 0,
 		},
 	},
 	descending: {
 		alphanumeric: {
+			/** @type {Comparator} */
 			sensitive: (a, b) =>
 				comparators.ascending.alphanumeric.sensitive(b, a),
+
+			/** @type {Comparator} */
 			insensitive: (a, b) =>
 				comparators.ascending.alphanumeric.insensitive(b, a),
 		},
 		natural: {
+			/** @type {Comparator} */
 			sensitive: (a, b) => comparators.ascending.natural.sensitive(b, a),
+
+			/** @type {Comparator} */
 			insensitive: (a, b) =>
 				comparators.ascending.natural.insensitive(b, a),
 		},
 	},
 };
 
+/**
+ * Gets the MemberNode's string key value.
+ * @param {MemberNode} member
+ * @return {string}
+ */
 function getKey(member) {
-	return member.name.type === `Identifier`
+	return member.name.type === "Identifier"
 		? member.name.name
 		: member.name.value;
 }
 
-export default {
+//-----------------------------------------------------------------------------
+// Rule Definition
+//-----------------------------------------------------------------------------
+
+/** @type {SortKeysRuleDefinition} */
+const rule = {
 	meta: {
-		type: /** @type {const} */ ("suggestion"),
+		type: "suggestion",
 
 		defaultOptions: [
 			"asc",
@@ -90,10 +139,11 @@ export default {
 	},
 
 	create(context) {
+		const options = /** @type {Array<string|Object>} */ (context.options);
 		const [
 			directionShort,
 			{ allowLineSeparatedGroups, caseSensitive, natural, minKeys },
-		] = context.options;
+		] = /** @type { SortKeysRuleOptions} */ (options);
 
 		const direction = directionShort === "asc" ? "ascending" : "descending";
 		const sortName = natural ? "natural" : "alphanumeric";
@@ -112,8 +162,14 @@ export default {
 			}
 		}
 
-		// Note that there can be comments *inside* members, e.g. `{"foo: /* comment *\/ "bar"}`, but these are ignored when calculating line-separated groups
+		/**
+		 * Checks if two members are line-separated.
+		 * @param {MemberNode} prevMember The previous member.
+		 * @param {MemberNode} member The current member.
+		 * @return {boolean}
+		 */
 		function isLineSeparated(prevMember, member) {
+			// Note that there can be comments *inside* members, e.g. `{"foo: /* comment *\/ "bar"}`, but these are ignored when calculating line-separated groups
 			const prevMemberEndLine = prevMember.loc.end.line;
 			const thisStartLine = member.loc.start.line;
 			if (thisStartLine - prevMemberEndLine < 2) {
@@ -176,3 +232,5 @@ export default {
 		};
 	},
 };
+
+export default rule;

--- a/src/rules/top-level-interop.js
+++ b/src/rules/top-level-interop.js
@@ -3,9 +3,21 @@
  * @author Joe Hildebrand
  */
 
-export default {
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/** @typedef {"topLevel"} TopLevelInteropMessageIds */
+/** @typedef {import("../types.ts").JSONRuleDefinition<[], TopLevelInteropMessageIds>} TopLevelInteropRuleDefinition */
+
+//-----------------------------------------------------------------------------
+// Rule Definition
+//-----------------------------------------------------------------------------
+
+/** @type {TopLevelInteropRuleDefinition} */
+const rule = {
 	meta: {
-		type: /** @type {const} */ ("problem"),
+		type: "problem",
 
 		docs: {
 			description:
@@ -33,3 +45,5 @@ export default {
 		};
 	},
 };
+
+export default rule;

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,16 @@ export interface IJSONSourceCode
 		beforeCount?: number,
 		afterCount?: number,
 	): string;
+
+	/**
+	 * Any comments found in a JSONC or JSON5 file.
+	 */
+	comments: Array<Token> | undefined;
+
+	/**
+	 * The lines of text found in the file.
+	 */
+	lines: Array<string>;
 }
 
 export type IJSONLanguage = Language<{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Updates types throughout.

#### What changes did you make? (Give an overview)

* [`src/rules/no-duplicate-keys.js`](diffhunk://#diff-969f0d66f1cfc2d4e41aadd9f8c363d0ec36ce01d966b9abc5ef1d5eef2ab22eL19-R19): Changed the rule definition to use a `const rule` and exported it separately. [[1]](diffhunk://#diff-969f0d66f1cfc2d4e41aadd9f8c363d0ec36ce01d966b9abc5ef1d5eef2ab22eL19-R19) [[2]](diffhunk://#diff-969f0d66f1cfc2d4e41aadd9f8c363d0ec36ce01d966b9abc5ef1d5eef2ab22eR69-R70)
* [`src/rules/no-empty-keys.js`](diffhunk://#diff-78a5bba7f29b557cf63ae6bf91225c924b3b26057b9b7850e5126e2287f604eaL18-R18): Changed the rule definition to use a `const rule` and exported it separately. [[1]](diffhunk://#diff-78a5bba7f29b557cf63ae6bf91225c924b3b26057b9b7850e5126e2287f604eaL18-R18) [[2]](diffhunk://#diff-78a5bba7f29b557cf63ae6bf91225c924b3b26057b9b7850e5126e2287f604eaR49-R50)
* [`src/rules/no-unnormalized-keys.js`](diffhunk://#diff-ad2f53c7694b48a8b17a53ebe26bc6040c6dc98944db81a71ea45bf9b86ad58eL6-R18): Added type definitions and changed the rule definition to use a `const rule`, exporting it separately. [[1]](diffhunk://#diff-ad2f53c7694b48a8b17a53ebe26bc6040c6dc98944db81a71ea45bf9b86ad58eL6-R18) [[2]](diffhunk://#diff-ad2f53c7694b48a8b17a53ebe26bc6040c6dc98944db81a71ea45bf9b86ad58eL32-R54) [[3]](diffhunk://#diff-ad2f53c7694b48a8b17a53ebe26bc6040c6dc98944db81a71ea45bf9b86ad58eR67-R68)
* [`src/rules/no-unsafe-values.js`](diffhunk://#diff-11dd33d46bf2c661525019259bfb6d035a277b681f90e55b2dfd97a08dba4371L33-R33): Changed the rule definition to use a `const rule` and exported it separately. [[1]](diffhunk://#diff-11dd33d46bf2c661525019259bfb6d035a277b681f90e55b2dfd97a08dba4371L33-R33) [[2]](diffhunk://#diff-11dd33d46bf2c661525019259bfb6d035a277b681f90e55b2dfd97a08dba4371R148-R149)
* [`src/rules/sort-keys.js`](diffhunk://#diff-0995683768dbc4acb84b58d727b7eb88d4965be70925a8832f1d955efe14db1aL2-R94): Added type definitions, imports, and helper functions. Changed the rule definition to use a `const rule` and exported it separately. [[1]](diffhunk://#diff-0995683768dbc4acb84b58d727b7eb88d4965be70925a8832f1d955efe14db1aL2-R94) [[2]](diffhunk://#diff-0995683768dbc4acb84b58d727b7eb88d4965be70925a8832f1d955efe14db1aR142-R146) [[3]](diffhunk://#diff-0995683768dbc4acb84b58d727b7eb88d4965be70925a8832f1d955efe14db1aL115-R172) [[4]](diffhunk://#diff-0995683768dbc4acb84b58d727b7eb88d4965be70925a8832f1d955efe14db1aR235-R236)
* [`src/rules/top-level-interop.js`](diffhunk://#diff-f87e916eb03fc306067053c7a54bb14ac8a859ca794e923b91c3cbacb462db95L6-R20): Added type definitions and changed the rule definition to use a `const rule`, exporting it separately. [[1]](diffhunk://#diff-f87e916eb03fc306067053c7a54bb14ac8a859ca794e923b91c3cbacb462db95L6-R20) [[2]](diffhunk://#diff-f87e916eb03fc306067053c7a54bb14ac8a859ca794e923b91c3cbacb462db95R48-R49)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R79): Added the `momoa` dependency.
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR108-R117): Added comments and lines properties to the `IJSONSourceCode` interface.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

I had to reformat the rules because the previous format of applying a type to the default export could only be accomplished with parentheses, and then Prettier would remove the parentheses on precommit. 

<!-- markdownlint-disable-file MD004 -->
