### PR TITLE
fix: Update `types.ts` for compatibility with `verbatimModuleSyntax`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ import type {
 	LanguageOptions,
 	RuleDefinition,
 } from "@eslint/core";
-import {
+import type {
 	DocumentNode,
 	MemberNode,
 	ElementNode,

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "../..",
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
   "files": [],
   "include": [".", "../../dist"]

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,5 +1,6 @@
 import json from "@eslint/json";
 import { ESLint } from "eslint";
+import type { JSONSyntaxElement } from "@eslint/json/types";
 
 json satisfies ESLint.Plugin;
 json.meta.name satisfies string;
@@ -21,3 +22,14 @@ json.configs.recommended.plugins satisfies object;
 	// Check that all recommended rule names match the names of existing rules in this plugin.
 	null as AssertAllNamesIn<RecommendedRuleName, RuleName>;
 }
+
+// Check that types are imported correctly from `@humanwhocodes/momoa`.
+({
+	start: { line: 1, column: 1, offset: 1 },
+	end: { line: 1, column: 1, offset: 1 },
+}) satisfies JSONSyntaxElement["loc"];
+({
+	// @ts-expect-error -- This is not a valid Location.
+	start: 100,
+	end: { line: 1, column: 1, offset: 1 },
+}) satisfies JSONSyntaxElement["loc"];


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

After using this package in with the new [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) TypeScript compiler option, I hit the below error.

```sh
error TS1484: 'ElementNode' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
error TS1484: 'ObjectNode' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
...
```

#### What changes did you make? (Give an overview)

Changed to a type-only import for imports from `@humanwhocodes/momoa`.

#### Related Issues

Related to #84.

#### Is there anything you'd like reviewers to focus on?

Only one line changed.
