### PR TITLE
test: re-enable `ESLint.Plugin` type test

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "c8": "^9.1.0",
     "dedent": "^1.5.3",
-    "eslint": "^9.11.1",
+    "eslint": "^9.23.0",
     "eslint-config-eslint": "^11.0.0",
     "eslint-plugin-eslint-plugin": "^6.3.2",
     "got": "^14.4.2",

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,7 +1,7 @@
 import json from "@eslint/json";
-// import { ESLint } from "eslint";
+import { ESLint } from "eslint";
 
-// json satisfies ESLint.Plugin;
+json satisfies ESLint.Plugin;
 json.meta.name satisfies string;
 json.meta.version satisfies string;
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add a type test

#### What changes did you make? (Give an overview)

Updated package.json to use the latest `eslint` version and re-enabled a type test to check if the plugin is assignable to `ESLint.Plugin`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

refs eslint/eslint#19531

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
