### PR TITLE
feat!: Update package types for better reuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "prettier": "^3.4.1",
     "rollup": "^4.16.2",
     "rollup-plugin-copy": "^3.5.0",
+    "rollup-plugin-delete": "^3.0.1",
     "typescript": "^5.4.5",
     "yorkie": "^2.0.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import copy from "rollup-plugin-copy";
+import del from "rollup-plugin-delete";
 
 export default {
 	input: "src/index.js",
@@ -14,6 +15,7 @@ export default {
 		},
 	],
 	plugins: [
+		del({ targets: "dist/*" }),
 		copy({
 			targets: [
 				{ src: "src/types.ts", dest: "dist/cjs", rename: "types.cts" },

--- a/src/index.js
+++ b/src/index.js
@@ -57,4 +57,5 @@ const plugin = {
 }
 
 export default plugin;
-export { JSONLanguage, JSONSourceCode };
+export { JSONSourceCode };
+export * from "./languages/json-language.js";

--- a/src/languages/json-language.js
+++ b/src/languages/json-language.js
@@ -15,14 +15,16 @@ import { visitorKeys } from "@humanwhocodes/momoa";
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("@humanwhocodes/momoa").DocumentNode} DocumentNode */
-/** @typedef {import("@humanwhocodes/momoa").Node} JSONNode */
-/** @typedef {import("@eslint/core").Language} Language */
-/** @typedef {import("@eslint/core").OkParseResult<DocumentNode>} OkParseResult */
-/** @typedef {import("@eslint/core").ParseResult<DocumentNode>} ParseResult */
-/** @typedef {import("@eslint/core").File} File */
-/** @typedef {import("../types.ts").IJSONLanguage} IJSONLanguage */
-/** @typedef {import("../types.ts").JSONLanguageOptions} JSONLanguageOptions */
+/**
+ * @import { DocumentNode, AnyNode } from "@humanwhocodes/momoa";
+ * @import { Language, OkParseResult, ParseResult, File } from "@eslint/core";
+ *
+ * @typedef {OkParseResult<DocumentNode>} JSONOkParseResult
+ * @typedef {ParseResult<DocumentNode>} JSONParseResult
+ *
+ * @typedef {Object} JSONLanguageOptions
+ * @property {boolean} [allowTrailingCommas] Whether to allow trailing commas in JSONC mode.
+ */
 
 //-----------------------------------------------------------------------------
 // Exports
@@ -30,7 +32,7 @@ import { visitorKeys } from "@humanwhocodes/momoa";
 
 /**
  * JSON Language Object
- * @implements {IJSONLanguage}
+ * @implements {Language<{ LangOptions: JSONLanguageOptions; Code: JSONSourceCode; RootNode: DocumentNode; Node: AnyNode }>}
  */
 export class JSONLanguage {
 	/**
@@ -107,7 +109,7 @@ export class JSONLanguage {
 	 * Parses the given file into an AST.
 	 * @param {File} file The virtual file to parse.
 	 * @param {{languageOptions: JSONLanguageOptions}} context The options to use for parsing.
-	 * @returns {ParseResult} The result of parsing.
+	 * @returns {JSONParseResult} The result of parsing.
 	 */
 	parse(file, context) {
 		// Note: BOM already removed
@@ -155,7 +157,7 @@ export class JSONLanguage {
 	/**
 	 * Creates a new `JSONSourceCode` object from the given information.
 	 * @param {File} file The virtual file to create a `JSONSourceCode` object from.
-	 * @param {OkParseResult} parseResult The result returned from `parse()`.
+	 * @param {JSONOkParseResult} parseResult The result returned from `parse()`.
 	 * @returns {JSONSourceCode} The new `JSONSourceCode` object.
 	 */
 	createSourceCode(file, parseResult) {

--- a/src/languages/json-source-code.js
+++ b/src/languages/json-source-code.js
@@ -20,13 +20,9 @@ import {
 //-----------------------------------------------------------------------------
 
 /**
- * @import { DocumentNode, AnyNode, Node, Token } from "@humanwhocodes/momoa";
- * @import {
- *     SourceRange, SourceLocation, File, FileProblem,
- *     DirectiveType, RulesConfig, TextSourceCode, TraversalStep,
- *     VisitTraversalStep
- *  } from "@eslint/core";
- * @import { JSONSyntaxElement } from "../types.js";
+ * @import { DocumentNode, Node, Token } from "@humanwhocodes/momoa";
+ * @import { SourceLocation, FileProblem, DirectiveType, RulesConfig, TextSourceCode} from "@eslint/core";
+ * @import { JSONSyntaxElement } from "../types.ts";
  * @import { JSONLanguageOptions } from "./json-language.js";
  */
 

--- a/src/languages/json-source-code.js
+++ b/src/languages/json-source-code.js
@@ -19,19 +19,16 @@ import {
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("@humanwhocodes/momoa").DocumentNode} DocumentNode */
-/** @typedef {import("@humanwhocodes/momoa").Node} JSONNode */
-/** @typedef {import("@humanwhocodes/momoa").Token} JSONToken */
-/** @typedef {import("@eslint/core").SourceRange} SourceRange */
-/** @typedef {import("@eslint/core").SourceLocation} SourceLocation */
-/** @typedef {import("@eslint/core").File} File */
-/** @typedef {import("@eslint/core").TraversalStep} TraversalStep */
-/** @typedef {import("@eslint/core").VisitTraversalStep} VisitTraversalStep */
-/** @typedef {import("@eslint/core").FileProblem} FileProblem */
-/** @typedef {import("@eslint/core").DirectiveType} DirectiveType */
-/** @typedef {import("@eslint/core").RulesConfig} RulesConfig */
-/** @typedef {import("../types.ts").IJSONSourceCode} IJSONSourceCode */
-/** @typedef {import("../types.ts").JSONSyntaxElement} JSONSyntaxElement */
+/**
+ * @import { DocumentNode, AnyNode, Node, Token } from "@humanwhocodes/momoa";
+ * @import {
+ *     SourceRange, SourceLocation, File, FileProblem,
+ *     DirectiveType, RulesConfig, TextSourceCode, TraversalStep,
+ *     VisitTraversalStep
+ *  } from "@eslint/core";
+ * @import { JSONSyntaxElement } from "../types.js";
+ * @import { JSONLanguageOptions } from "./json-language.js";
+ */
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -48,14 +45,14 @@ const INLINE_CONFIG =
 class JSONTraversalStep extends VisitNodeStep {
 	/**
 	 * The target of the step.
-	 * @type {JSONNode}
+	 * @type {Node}
 	 */
 	target = undefined;
 
 	/**
 	 * Creates a new instance.
 	 * @param {Object} options The options for the step.
-	 * @param {JSONNode} options.target The target of the step.
+	 * @param {Node} options.target The target of the step.
 	 * @param {1|2} options.phase The phase of the step.
 	 * @param {Array<any>} options.args The arguments of the step.
 	 */
@@ -72,7 +69,7 @@ class JSONTraversalStep extends VisitNodeStep {
 
 /**
  * JSON Source Code Object
- * @implements {IJSONSourceCode}
+ * @implements {TextSourceCode<{LangOptions: JSONLanguageOptions, RootNode: DocumentNode, SyntaxElementWithLoc: JSONSyntaxElement, ConfigNode: Token}>}
  */
 export class JSONSourceCode extends TextSourceCodeBase {
 	/**
@@ -83,13 +80,13 @@ export class JSONSourceCode extends TextSourceCodeBase {
 
 	/**
 	 * Cache of parent nodes.
-	 * @type {WeakMap<JSONNode, JSONNode>}
+	 * @type {WeakMap<Node, Node>}
 	 */
 	#parents = new WeakMap();
 
 	/**
 	 * Collection of inline configuration comments.
-	 * @type {Array<JSONToken>}
+	 * @type {Array<Token>}
 	 */
 	#inlineConfigComments;
 
@@ -101,7 +98,7 @@ export class JSONSourceCode extends TextSourceCodeBase {
 
 	/**
 	 * The comment node in the source code.
-	 * @type {Array<JSONToken>|undefined}
+	 * @type {Array<Token>|undefined}
 	 */
 	comments;
 
@@ -121,7 +118,7 @@ export class JSONSourceCode extends TextSourceCodeBase {
 
 	/**
 	 * Returns the value of the given comment.
-	 * @param {JSONToken} comment The comment to get the value of.
+	 * @param {Token} comment The comment to get the value of.
 	 * @returns {string} The value of the comment.
 	 * @throws {Error} When an unexpected comment type is passed.
 	 */
@@ -140,7 +137,7 @@ export class JSONSourceCode extends TextSourceCodeBase {
 	/**
 	 * Returns an array of all inline configuration nodes found in the
 	 * source code.
-	 * @returns {Array<JSONToken>} An array of all inline configuration nodes.
+	 * @returns {Array<Token>} An array of all inline configuration nodes.
 	 */
 	getInlineConfigNodes() {
 		if (!this.#inlineConfigComments) {
@@ -251,8 +248,8 @@ export class JSONSourceCode extends TextSourceCodeBase {
 
 	/**
 	 * Returns the parent of the given node.
-	 * @param {JSONNode} node The node to get the parent of.
-	 * @returns {JSONNode|undefined} The parent of the node.
+	 * @param {Node} node The node to get the parent of.
+	 * @returns {Node|undefined} The parent of the node.
 	 */
 	getParent(node) {
 		return this.#parents.get(node);

--- a/src/rules/no-duplicate-keys.js
+++ b/src/rules/no-duplicate-keys.js
@@ -7,9 +7,13 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {"duplicateKey"} NoDuplicateKeysMessageIds */
-/** @typedef {import("../types.ts").JSONRuleDefinition<[], NoDuplicateKeysMessageIds>} NoDuplicateKeysRuleDefinition */
-/** @typedef {import("@humanwhocodes/momoa").MemberNode} MemberNode */
+/**
+ * @import { MemberNode } from "@humanwhocodes/momoa";
+ * @import { JSONRuleDefinition } from "../types.ts";
+ *
+ * @typedef {"duplicateKey"} NoDuplicateKeysMessageIds
+ * @typedef {JSONRuleDefinition<{ MessageIds: NoDuplicateKeysMessageIds }>} NoDuplicateKeysRuleDefinition
+ */
 
 //-----------------------------------------------------------------------------
 // Rule Definition

--- a/src/rules/no-empty-keys.js
+++ b/src/rules/no-empty-keys.js
@@ -7,8 +7,12 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {"emptyKey"} NoEmptyKeysMessageIds */
-/** @typedef {import("../types.ts").JSONRuleDefinition<[], NoEmptyKeysMessageIds>} NoEmptyKeysRuleDefinition */
+/**
+ * @import { JSONRuleDefinition } from "../types.ts";
+ *
+ * @typedef {"emptyKey"} NoEmptyKeysMessageIds
+ * @typedef {JSONRuleDefinition<{ MessageIds: NoEmptyKeysMessageIds }>} NoEmptyKeysRuleDefinition
+ */
 
 //-----------------------------------------------------------------------------
 // Rule Definition

--- a/src/rules/no-unnormalized-keys.js
+++ b/src/rules/no-unnormalized-keys.js
@@ -7,8 +7,13 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {"unnormalizedKey"} NoUnnormalizedKeysMessageIds */
-/** @typedef {import("../types.ts").JSONRuleDefinition<[{form:string}], NoUnnormalizedKeysMessageIds>} NoUnnormalizedKeysRuleDefinition */
+/**
+ * @import { JSONRuleDefinition } from "../types.ts";
+ *
+ * @typedef {"unnormalizedKey"} NoUnnormalizedKeysMessageIds
+ * @typedef {{ form: string }} NoUnnormalizedKeysOptions
+ * @typedef {JSONRuleDefinition<{ RuleOptions: [NoUnnormalizedKeysOptions], MessageIds: NoUnnormalizedKeysMessageIds }>} NoUnnormalizedKeysRuleDefinition
+ */
 
 //-----------------------------------------------------------------------------
 // Rule Definition

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -7,8 +7,12 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {"unsafeNumber"|"unsafeInteger"|"unsafeZero"|"subnormal"|"loneSurrogate"} NoUnsafeValuesMessageIds */
-/** @typedef {import("../types.ts").JSONRuleDefinition<[], NoUnsafeValuesMessageIds>} NoUnsafeValuesRuleDefinition */
+/**
+ * @import { JSONRuleDefinition } from "../types.ts";
+ *
+ * @typedef {"unsafeNumber"|"unsafeInteger"|"unsafeZero"|"subnormal"|"loneSurrogate"} NoUnsafeValuesMessageIds
+ * @typedef {JSONRuleDefinition<{ MessageIds: NoUnsafeValuesMessageIds }>} NoUnsafeValuesRuleDefinition
+ */
 
 //-----------------------------------------------------------------------------
 // Helpers

--- a/src/rules/sort-keys.js
+++ b/src/rules/sort-keys.js
@@ -14,21 +14,22 @@ import naturalCompare from "natural-compare";
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {"sortKeys"} SortKeysMessageIds */
-
 /**
+ * @import { JSONRuleDefinition } from "../types.ts";
+ * @import { MemberNode } from "@humanwhocodes/momoa";
+ *
  * @typedef {Object} SortOptions
  * @property {boolean} caseSensitive
  * @property {boolean} natural
  * @property {number} minKeys
  * @property {boolean} allowLineSeparatedGroups
+ *
+ * @typedef {"sortKeys"} SortKeysMessageIds
+ * @typedef {"asc"|"desc"} SortDirection
+ * @typedef {[SortDirection, SortOptions]} SortKeysRuleOptions
+ * @typedef {JSONRuleDefinition<{ RuleOptions: SortKeysRuleOptions, MessageIds: SortKeysMessageIds }>} SortKeysRuleDefinition
+ * @typedef {(a:string,b:string) => boolean} Comparator
  */
-
-/** @typedef {"asc"|"desc"} SortDirection */
-/** @typedef {[SortDirection, SortOptions]} SortKeysRuleOptions */
-/** @typedef {import("../types.ts").JSONRuleDefinition<SortKeysRuleOptions, SortKeysMessageIds>} SortKeysRuleDefinition */
-/** @typedef {(a:string,b:string) => boolean} Comparator */
-/** @typedef {import("@humanwhocodes/momoa").MemberNode} MemberNode */
 
 //-----------------------------------------------------------------------------
 // Helpers

--- a/src/rules/top-level-interop.js
+++ b/src/rules/top-level-interop.js
@@ -7,8 +7,12 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {"topLevel"} TopLevelInteropMessageIds */
-/** @typedef {import("../types.ts").JSONRuleDefinition<[], TopLevelInteropMessageIds>} TopLevelInteropRuleDefinition */
+/**
+ * @import { JSONRuleDefinition } from "../types.ts";
+ *
+ * @typedef {"topLevel"} TopLevelInteropMessageIds
+ * @typedef {JSONRuleDefinition<{ MessageIds: TopLevelInteropMessageIds }>} TopLevelInteropRuleDefinition
+ */
 
 //-----------------------------------------------------------------------------
 // Rule Definition

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ import type {
 	AnyNode,
 	Token,
 } from "@humanwhocodes/momoa";
-import { JSONLanguageOptions, JSONSourceCode } from "./index.js";
+import type { JSONLanguageOptions, JSONSourceCode } from "./index.js";
 
 //------------------------------------------------------------------------------
 // Types

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,7 @@ import type {
 	AnyNode,
 	Token,
 } from "@humanwhocodes/momoa";
-import { JSONLanguageOptions } from "./languages/json-language.js";
-import { JSONSourceCode } from "./languages/json-source-code.js";
+import { JSONLanguageOptions, JSONSourceCode } from "./index.js";
 
 //------------------------------------------------------------------------------
 // Types

--- a/tools/build-cts.js
+++ b/tools/build-cts.js
@@ -3,14 +3,19 @@
  * This script creates "dist/cjs/index.d.cts" from "dist/esm/index.d.ts" by modifying imports
  * from `"./types.ts"` to `"./types.cts"`.
  *
+ * Also updates "types.cts" to reference "index.cts"
+ *
  * @author Francesco Trotta
  */
 
 import { readFile, writeFile } from "node:fs/promises";
 
 const oldSourceText = await readFile("dist/esm/index.d.ts", "utf-8");
-const newSourceText = oldSourceText.replaceAll(
-	'import("./types.ts")',
-	'import("./types.cts")',
-);
+const newSourceText = oldSourceText.replaceAll('"./types.ts"', '"./types.cts"');
 await writeFile("dist/cjs/index.d.cts", newSourceText);
+
+// Now update the types.cts to reference index.cts
+const typesText = await readFile("dist/cjs/types.cts", "utf-8");
+const updatedTypesText = typesText.replaceAll('"./index.js"', '"./index.cjs"');
+
+await writeFile("dist/cjs/types.cts", updatedTypesText);

--- a/tools/dedupe-types.js
+++ b/tools/dedupe-types.js
@@ -4,7 +4,7 @@
  * it encounters a duplicate typedef.
  *
  * Usage:
- *  node scripts/strip-typedefs.js filename1.js filename2.js ...
+ *  node scripts/dedupe-types.js filename1.js filename2.js ...
  *
  * @author Nicholas C. Zakas
  */
@@ -19,25 +19,60 @@ import fs from "node:fs";
 // Main
 //-----------------------------------------------------------------------------
 
+const importRegExp =
+	/^\s*\*\s*@import\s*\{\s*(?<ids>[^,}]+(?:\s*,\s*[^,}]+)*)\s*\}\s*from\s*"(?<source>[^"]+)"/u;
+
 // read files from the command line
 const files = process.argv.slice(2);
 
 files.forEach(filePath => {
 	const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/gu);
-	const typedefs = new Set();
+	const imports = new Map();
 
+	// find all imports and remove them
 	const remainingLines = lines.filter(line => {
-		if (!line.startsWith("/** @typedef {import")) {
+		if (!line.startsWith(" * @import")) {
 			return true;
 		}
 
-		if (typedefs.has(line)) {
-			return false;
+		const match = importRegExp.exec(line);
+
+		if (!match) {
+			throw Error("Something is very wrong");
 		}
 
-		typedefs.add(line);
-		return true;
+		const source = match.groups.source;
+		const ids = match.groups.ids.split(/,/gu).map(id => id.trim());
+
+		// save the import data
+
+		if (!imports.has(source)) {
+			imports.set(source, new Set());
+		}
+
+		const existingIds = imports.get(source);
+		ids.forEach(id => existingIds.add(id));
+
+		return false;
 	});
+
+	// create a new import statement for each unique import
+	const jsdocBlock = ["/**"];
+
+	imports.forEach((ids, source) => {
+		// if it's a local file, we don't need it
+		if (source.startsWith("./")) {
+			return;
+		}
+
+		const idList = Array.from(ids).join(", ");
+		jsdocBlock.push(` * @import { ${idList} } from "${source}"`);
+	});
+
+	// add the new import statements to the top of the file
+	jsdocBlock.push(" */");
+	remainingLines.unshift(...jsdocBlock);
+	remainingLines.unshift(""); // add a blank line before the block
 
 	// replace references to ../types.ts with ./types.ts
 	const text = remainingLines

--- a/tools/dedupe-types.js
+++ b/tools/dedupe-types.js
@@ -4,7 +4,7 @@
  * it encounters a duplicate typedef.
  *
  * Usage:
- *  node scripts/dedupe-types.js filename1.js filename2.js ...
+ *  node tools/dedupe-types.js filename1.js filename2.js ...
  *
  * @author Nicholas C. Zakas
  */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To simplify and extend the existing types in the package.

#### What changes did you make? (Give an overview)

Primarily:

1. Switched to using `@import` in JSDoc comments, which allows importing generic types. That allowed a bunch of optimizations.
1. Removed `IJSONLanguage` and `IJSONSourceCode`, swapping them out for the actual classes, both of which now have an `@implements` directly on their declarations.
1. Updated `JSONRuleDefinition` based on discussion with @fasttime.
1. Updated all of the rules accordingly. 
1. Updated `dedupe-types.js` to take into account `@import` statements.

Specifics:

* [`src/languages/json-language.js`](diffhunk://#diff-946ef0a1cd314d57cad8d20980143652c62ee216c556246c67e13875ded7180aL18-R35): Consolidated type definitions and import statements for `@humanwhocodes/momoa` and `@eslint/core`, and updated the `JSONLanguage` class to use the new consolidated types. [[1]](diffhunk://#diff-946ef0a1cd314d57cad8d20980143652c62ee216c556246c67e13875ded7180aL18-R35) [[2]](diffhunk://#diff-946ef0a1cd314d57cad8d20980143652c62ee216c556246c67e13875ded7180aL110-R112) [[3]](diffhunk://#diff-946ef0a1cd314d57cad8d20980143652c62ee216c556246c67e13875ded7180aL158-R160)
* [`src/languages/json-source-code.js`](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L22-R31): Consolidated type definitions and import statements, and updated the `JSONSourceCode` class to use the new consolidated types. [[1]](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L22-R31) [[2]](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L51-R55) [[3]](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L75-R72) [[4]](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L86-R89) [[5]](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L104-R101) [[6]](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L124-R121) [[7]](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L143-R140) [[8]](diffhunk://#diff-cef80a0fa209c9c327a7890fc9fb9b4a79c5094831f8453f2ff30c6d79322c00L254-R252)
* [`src/rules/no-duplicate-keys.js`](diffhunk://#diff-969f0d66f1cfc2d4e41aadd9f8c363d0ec36ce01d966b9abc5ef1d5eef2ab22eL10-R16): Consolidated type definitions and import statements for `@humanwhocodes/momoa` and `../types.ts`, and updated the rule definition to use the new consolidated types.
* [`src/rules/no-empty-keys.js`](diffhunk://#diff-78a5bba7f29b557cf63ae6bf91225c924b3b26057b9b7850e5126e2287f604eaL10-R15): Consolidated type definitions and import statements for `../types.ts`, and updated the rule definition to use the new consolidated types.
* [`src/rules/no-unnormalized-keys.js`](diffhunk://#diff-ad2f53c7694b48a8b17a53ebe26bc6040c6dc98944db81a71ea45bf9b86ad58eL10-R16): Consolidated type definitions and import statements for `../types.ts`, and updated the rule definition to use the new consolidated types.
* [`src/rules/no-unsafe-values.js`](diffhunk://#diff-11dd33d46bf2c661525019259bfb6d035a277b681f90e55b2dfd97a08dba4371L10-R15): Consolidated type definitions and import statements for `../types.ts`, and updated the rule definition to use the new consolidated types.
* [`src/rules/sort-keys.js`](diffhunk://#diff-0995683768dbc4acb84b58d727b7eb88d4965be70925a8832f1d955efe14db1aL17-L32): Consolidated type definitions and import statements for `@humanwhocodes/momoa` and `../types.ts`, and updated the rule definition to use the new consolidated types.
* [`src/rules/top-level-interop.js`](diffhunk://#diff-f87e916eb03fc306067053c7a54bb14ac8a859ca794e923b91c3cbacb462db95L10-R15): Consolidated type definitions and import statements for `../types.ts`, and updated the rule definition to use the new consolidated types.
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL10-R10): Removed redundant type definitions and consolidated imports, and updated the `JSONRuleDefinition` type to use a more flexible and consolidated structure. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL10-R10) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR27-R28) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL45-L54) [[4]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL86-R93)

#### Related Issues

refs https://github.com/eslint/eslint/issues/19521

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
