### PR TITLE
test: create tests for `JSONRuleDefinition`

### DIFF
--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,6 +1,6 @@
 import json from "@eslint/json";
 import { ESLint } from "eslint";
-import type { JSONSyntaxElement } from "@eslint/json/types";
+import type { JSONSyntaxElement, JSONRuleDefinition } from "@eslint/json/types";
 
 json satisfies ESLint.Plugin;
 json.meta.name satisfies string;
@@ -33,3 +33,75 @@ json.configs.recommended.plugins satisfies object;
 	start: 100,
 	end: { line: 1, column: 1, offset: 1 },
 }) satisfies JSONSyntaxElement["loc"];
+
+// All options optional - JSONRuleDefinition and JSONRuleDefinition<{}>
+// should be the same type.
+(rule1: JSONRuleDefinition, rule2: JSONRuleDefinition<{}>) => {
+	rule1 satisfies typeof rule2;
+	rule2 satisfies typeof rule1;
+};
+
+// Type restrictions should be enforced
+(): JSONRuleDefinition<{
+	RuleOptions: [string, number];
+	MessageIds: "foo" | "bar";
+	ExtRuleDocs: { foo: string; bar: number };
+}> => ({
+	meta: {
+		messages: {
+			foo: "FOO",
+
+			// @ts-expect-error Wrong type for message ID
+			bar: 42,
+		},
+		docs: {
+			foo: "FOO",
+
+			// @ts-expect-error Wrong type for declared property
+			bar: "BAR",
+
+			// @ts-expect-error Wrong type for predefined property
+			description: 42,
+		},
+	},
+	create({ options }) {
+		// Types for rule options
+		options[0] satisfies string;
+		options[1] satisfies number;
+
+		return {};
+	},
+});
+
+// Undeclared properties should produce an error
+(): JSONRuleDefinition<{
+	MessageIds: "foo" | "bar";
+	ExtRuleDocs: { foo: number; bar: string };
+}> => ({
+	meta: {
+		messages: {
+			foo: "FOO",
+
+			// Declared message ID is not required
+			// bar: "BAR",
+
+			// @ts-expect-error Undeclared message ID is not allowed
+			baz: "BAZ",
+		},
+		docs: {
+			foo: 42,
+
+			// Declared property is not required
+			// bar: "BAR",
+
+			// @ts-expect-error Undeclared property key is not allowed
+			baz: "BAZ",
+
+			// Predefined property is allowed
+			description: "Lorem ipsum",
+		},
+	},
+	create() {
+		return {};
+	},
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

I've implemented tests for `JSONRuleDefinition` by referencing the existing test in [`@eslint/markdown`](https://github.com/eslint/markdown/blob/main/tests/types/types.test.ts#L87-L162).

#### What changes did you make? (Give an overview)

I've added some tests.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
