### PR TITLE
refactor: switch JSONSourceCode to extend TextSourceCodeBase

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@eslint/core": "^0.12.0",
-    "@eslint/plugin-kit": "^0.2.7",
+    "@eslint/core": "^0.14.0",
+    "@eslint/plugin-kit": "^0.3.0",
     "@humanwhocodes/momoa": "^3.3.4",
     "natural-compare": "^1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@eslint/core": "^0.14.0",
-    "@eslint/plugin-kit": "^0.3.0",
+    "@eslint/plugin-kit": "^0.3.1",
     "@humanwhocodes/momoa": "^3.3.4",
     "natural-compare": "^1.4.0"
   },

--- a/src/languages/json-source-code.js
+++ b/src/languages/json-source-code.js
@@ -20,8 +20,8 @@ import {
 //-----------------------------------------------------------------------------
 
 /**
- * @import { DocumentNode, Node, Token } from "@humanwhocodes/momoa";
- * @import { SourceLocation, FileProblem, DirectiveType, RulesConfig, TextSourceCode} from "@eslint/core";
+ * @import { DocumentNode, AnyNode, Token } from "@humanwhocodes/momoa";
+ * @import { SourceLocation, FileProblem, DirectiveType, RulesConfig } from "@eslint/core";
  * @import { JSONSyntaxElement } from "../types.ts";
  * @import { JSONLanguageOptions } from "./json-language.js";
  */
@@ -41,14 +41,14 @@ const INLINE_CONFIG =
 class JSONTraversalStep extends VisitNodeStep {
 	/**
 	 * The target of the step.
-	 * @type {Node}
+	 * @type {AnyNode}
 	 */
 	target = undefined;
 
 	/**
 	 * Creates a new instance.
 	 * @param {Object} options The options for the step.
-	 * @param {Node} options.target The target of the step.
+	 * @param {AnyNode} options.target The target of the step.
 	 * @param {1|2} options.phase The phase of the step.
 	 * @param {Array<any>} options.args The arguments of the step.
 	 */
@@ -65,7 +65,7 @@ class JSONTraversalStep extends VisitNodeStep {
 
 /**
  * JSON Source Code Object
- * @implements {TextSourceCode<{LangOptions: JSONLanguageOptions, RootNode: DocumentNode, SyntaxElementWithLoc: JSONSyntaxElement, ConfigNode: Token}>}
+ * @extends {TextSourceCodeBase<{LangOptions: JSONLanguageOptions, RootNode: DocumentNode, SyntaxElementWithLoc: JSONSyntaxElement, ConfigNode: Token}>}
  */
 export class JSONSourceCode extends TextSourceCodeBase {
 	/**
@@ -76,7 +76,7 @@ export class JSONSourceCode extends TextSourceCodeBase {
 
 	/**
 	 * Cache of parent nodes.
-	 * @type {WeakMap<Node, Node>}
+	 * @type {WeakMap<AnyNode, AnyNode>}
 	 */
 	#parents = new WeakMap();
 
@@ -244,8 +244,8 @@ export class JSONSourceCode extends TextSourceCodeBase {
 
 	/**
 	 * Returns the parent of the given node.
-	 * @param {Node} node The node to get the parent of.
-	 * @returns {Node|undefined} The parent of the node.
+	 * @param {AnyNode} node The node to get the parent of.
+	 * @returns {AnyNode|undefined} The parent of the node.
 	 */
 	getParent(node) {
 		return this.#parents.get(node);
@@ -266,12 +266,15 @@ export class JSONSourceCode extends TextSourceCodeBase {
 
 		for (const { node, parent, phase } of iterator(this.ast)) {
 			if (parent) {
-				this.#parents.set(node, parent);
+				this.#parents.set(
+					/** @type {AnyNode} */ (node),
+					/** @type {AnyNode} */ (parent),
+				);
 			}
 
 			steps.push(
 				new JSONTraversalStep({
-					target: node,
+					target: /** @type {AnyNode} */ (node),
 					phase: phase === "enter" ? 1 : 2,
 					args: [node, parent],
 				}),

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,6 +1,26 @@
-import json from "@eslint/json";
+import json, { JSONSourceCode } from "@eslint/json";
 import { ESLint } from "eslint";
-import type { JSONSyntaxElement, JSONRuleDefinition } from "@eslint/json/types";
+import type {
+	JSONSyntaxElement,
+	JSONRuleDefinition,
+	JSONRuleVisitor,
+} from "@eslint/json/types";
+import type {
+	AnyNode,
+	ArrayNode,
+	BooleanNode,
+	DocumentNode,
+	ElementNode,
+	IdentifierNode,
+	InfinityNode,
+	MemberNode,
+	NaNNode,
+	NullNode,
+	NumberNode,
+	ObjectNode,
+	StringNode,
+} from "@humanwhocodes/momoa";
+import type { SourceLocation, SourceRange } from "@eslint/core";
 
 json satisfies ESLint.Plugin;
 json.meta.name satisfies string;
@@ -33,6 +53,59 @@ json.configs.recommended.plugins satisfies object;
 	start: 100,
 	end: { line: 1, column: 1, offset: 1 },
 }) satisfies JSONSyntaxElement["loc"];
+
+(): JSONRuleDefinition => ({
+	create({ sourceCode }): JSONRuleVisitor {
+		sourceCode satisfies JSONSourceCode;
+		sourceCode.ast satisfies DocumentNode;
+		sourceCode.lines satisfies string[];
+		sourceCode.text satisfies string;
+
+		function testVisitor<NodeType extends AnyNode>(
+			node: NodeType,
+			parent?:
+				| DocumentNode
+				| MemberNode
+				| ElementNode
+				| ArrayNode
+				| ObjectNode,
+		) {
+			sourceCode.getLoc(node) satisfies SourceLocation;
+			sourceCode.getRange(node) satisfies SourceRange;
+			sourceCode.getParent(node) satisfies AnyNode | undefined;
+			sourceCode.getAncestors(node) satisfies JSONSyntaxElement[];
+			sourceCode.getText(node) satisfies string;
+		}
+
+		return {
+			Array: (...args) => testVisitor<ArrayNode>(...args),
+			"Array:exit": (...args) => testVisitor<ArrayNode>(...args),
+			Boolean: (...args) => testVisitor<BooleanNode>(...args),
+			"Boolean:exit": (...args) => testVisitor<BooleanNode>(...args),
+			Document: (...args) => testVisitor<DocumentNode>(...args),
+			"Document:exit": (...args) => testVisitor<DocumentNode>(...args),
+			Element: (...args) => testVisitor<ElementNode>(...args),
+			"Element:exit": (...args) => testVisitor<ElementNode>(...args),
+			Identifier: (...args) => testVisitor<IdentifierNode>(...args),
+			"Identifier:exit": (...args) =>
+				testVisitor<IdentifierNode>(...args),
+			Infinity: (...args) => testVisitor<InfinityNode>(...args),
+			"Infinity:exit": (...args) => testVisitor<InfinityNode>(...args),
+			Member: (...args) => testVisitor<MemberNode>(...args),
+			"Member:exit": (...args) => testVisitor<MemberNode>(...args),
+			NaN: (...args) => testVisitor<NaNNode>(...args),
+			"NaN:exit": (...args) => testVisitor<NaNNode>(...args),
+			Null: (...args) => testVisitor<NullNode>(...args),
+			"Null:exit": (...args) => testVisitor<NullNode>(...args),
+			Number: (...args) => testVisitor<NumberNode>(...args),
+			"Number:exit": (...args) => testVisitor<NumberNode>(...args),
+			Object: (...args) => testVisitor<ObjectNode>(...args),
+			"Object:exit": (...args) => testVisitor<ObjectNode>(...args),
+			String: (...args) => testVisitor<StringNode>(...args),
+			"String:exit": (...args) => testVisitor<StringNode>(...args),
+		};
+	},
+});
 
 // All options optional - JSONRuleDefinition and JSONRuleDefinition<{}>
 // should be the same type.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request updates `JSONSourceCode` to extend `TextSourceCodeBase`

#### What changes did you make? (Give an overview)

- Upgraded @eslint/core and @eslint/plugin-kit to latest versions
- Switched `JSONSourceCode` to extend `TextSourceCodeBase`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
