### PR TITLE
chore: bump dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,19 +79,19 @@
     "natural-compare": "^1.4.0"
   },
   "devDependencies": {
-    "c8": "^9.1.0",
+    "c8": "^10.1.3",
     "dedent": "^1.5.3",
     "eslint": "^9.25.1",
     "eslint-config-eslint": "^11.0.0",
     "eslint-plugin-eslint-plugin": "^6.3.2",
     "got": "^14.4.2",
     "lint-staged": "^15.2.7",
-    "mocha": "^10.4.0",
+    "mocha": "^11.3.0",
     "prettier": "^3.4.1",
-    "rollup": "^4.16.2",
+    "rollup": "^4.41.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-delete": "^3.0.1",
-    "typescript": "^5.4.5",
+    "typescript": "^5.8.3",
     "yorkie": "^2.0.0"
   },
   "engines": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

In this PR, I've bumped versions of dev-dependencies.

#### What changes did you make? (Give an overview)

I've bumped `c8`, `mocha`, `rollup`, and `typescript`.

* **`c8`**
  This is a major version update. The only breaking change is that the minimum supported Node.js version is now Node.js 18, which is compatible with ESLint.
  [https://github.com/bcoe/c8/releases/tag/v10.0.0](https://github.com/bcoe/c8/releases/tag/v10.0.0)

* **`mocha`**
  This is also a major version update. The only breaking change is the minimum Node.js version requirement, which is now Node.js 18—still compatible with ESLint.
  [https://github.com/mochajs/mocha/releases/tag/v11.0.0](https://github.com/mochajs/mocha/releases/tag/v11.0.0)

* **`rollup` and `typescript`**
  These were already using a caret (`^`) version range, so technically no update was required. However, since there was a noticeable gap between the previously installed versions and the latest ones, I updated them as well for consistency.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
