### PR TITLE
docs: fix wrong `bun` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn add @eslint/json -D
 # or
 pnpm install @eslint/json -D
 # or
-bun install @eslint/json -D
+bun add @eslint/json -D
 ```
 
 For Deno:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've fixed wrong `bun` command.

This is follow-up to https://github.com/eslint/rewrite/pull/222.

Currently, the command `bun install package` doesn’t work as expected — the correct command is `bun add`.

References:
- https://bun.sh/docs/cli/install
- https://bun.sh/docs/cli/add

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
