### PR TITLE
test: add tests for JSON5 parsing in `JSONLanguage`

### DIFF
--- a/src/languages/json-language.js
+++ b/src/languages/json-language.js
@@ -1,5 +1,5 @@
 /**
- * @filedescription Functions to fix up rules to provide missing methods on the `context` object.
+ * @filedescription The JSONLanguage class.
  * @author Nicholas C. Zakas
  */
 

--- a/tests/languages/json-language.test.js
+++ b/tests/languages/json-language.test.js
@@ -142,11 +142,23 @@ describe("JSONLanguage", () => {
 			assert.strictEqual(result.ast.body.type, "Object");
 		});
 
-		it("should set the mode to jsonc", () => {
+		it("should parse jsonc", () => {
 			const language = new JSONLanguage({ mode: "jsonc" });
 			const result = language.parse({
 				body: "{\n//test\n}",
 				path: "test.jsonc",
+			});
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.ast.type, "Document");
+			assert.strictEqual(result.ast.body.type, "Object");
+		});
+
+		it("should parse json5", () => {
+			const language = new JSONLanguage({ mode: "json5" });
+			const result = language.parse({
+				body: '{\nfoo: "bar"\n}',
+				path: "test.json5",
 			});
 
 			assert.strictEqual(result.ok, true);
@@ -161,8 +173,8 @@ describe("JSONLanguage", () => {
 			const file = { body: "{\n\n}", path: "test.json" };
 			const parseResult = language.parse(file);
 			const sourceCode = language.createSourceCode(file, parseResult);
-			assert.strictEqual(sourceCode.constructor.name, "JSONSourceCode");
 
+			assert.strictEqual(sourceCode.constructor.name, "JSONSourceCode");
 			assert.strictEqual(sourceCode.ast.type, "Document");
 			assert.strictEqual(sourceCode.ast.body.type, "Object");
 			assert.strictEqual(sourceCode.text, "{\n\n}");
@@ -180,11 +192,27 @@ describe("JSONLanguage", () => {
 			);
 
 			assert.strictEqual(sourceCode.constructor.name, "JSONSourceCode");
-
 			assert.strictEqual(sourceCode.ast.type, "Document");
 			assert.strictEqual(sourceCode.ast.body.type, "Object");
 			assert.strictEqual(sourceCode.text, "{\n//test\n}");
 			assert.strictEqual(sourceCode.comments.length, 1);
+		});
+
+		it("should create a JSONSourceCode instance for JSON5", () => {
+			const language = new JSONLanguage({ mode: "json5" });
+			const file = { body: '{\nfoo: "bar"\n}', path: "test.json5" };
+			const parseResult = language.parse(file);
+			const sourceCode = language.createSourceCode(
+				file,
+				parseResult,
+				"test.json5",
+			);
+
+			assert.strictEqual(sourceCode.constructor.name, "JSONSourceCode");
+			assert.strictEqual(sourceCode.ast.type, "Document");
+			assert.strictEqual(sourceCode.ast.body.type, "Object");
+			assert.strictEqual(sourceCode.text, '{\nfoo: "bar"\n}');
+			assert.strictEqual(sourceCode.comments.length, 0);
 		});
 	});
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

In this PR, I've added tests for JSON5 parsing in `JSONLanguage`.

I noticed that test cases for JSON5 parsing were missing, so I added them.

Additionally, I fixed some typos and removed unnecessary empty spaces for style formatting.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
