### PR TITLE
chore: workaround for ci error caused by `minimatch` and `prettier`

### DIFF
--- a/docs/rules/no-unnormalized-keys.md
+++ b/docs/rules/no-unnormalized-keys.md
@@ -60,7 +60,6 @@ The following options are available on this rule:
 - `form: "NFC" | "NFD" | "NFKC" | "NFKD"` - specifies which Unicode normalization form to use when checking keys. Must be one of: `"NFC"` (default), `"NFD"`, `"NFKC"`, or `"NFKD"`.
 
     Each normalization form has specific characteristics:
-
     - **NFC**: Canonical Decomposition followed by Canonical Composition (default)
     - **NFD**: Canonical Decomposition
     - **NFKC**: Compatibility Decomposition followed by Canonical Composition

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "natural-compare": "^1.4.0"
   },
   "devDependencies": {
+    "@types/minimatch": "^5.1.2",
     "c8": "^10.1.3",
     "dedent": "^1.5.3",
     "eslint": "^9.25.1",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

I’m not sure why the CI error occurs either, but installing `@types/minimatch` resolved it 😅

The CI failure is currently blocking PRs in the JSON and CSS repos. It might be best to merge this PR as a workaround for now and revert it once we identify the root cause.

#### What changes did you make? (Give an overview)

Fixed CI errors

#### Related Issues

Ref: https://github.com/eslint/css/issues/188

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
