### PR TITLE
refactor: add missing type annotations to variables

### DIFF
--- a/src/languages/json-source-code.js
+++ b/src/languages/json-source-code.js
@@ -197,7 +197,9 @@ export class JSONSourceCode extends TextSourceCodeBase {
 	 *      that ESLint needs to further process the directives.
 	 */
 	getDisableDirectives() {
+		/** @type {Array<FileProblem>} */
 		const problems = [];
+		/** @type {Array<Directive>} */
 		const directives = [];
 
 		this.getInlineConfigNodes().forEach(comment => {
@@ -250,7 +252,9 @@ export class JSONSourceCode extends TextSourceCodeBase {
 	 *      that ESLint needs to further process the rule configurations.
 	 */
 	applyInlineConfig() {
+		/** @type {Array<FileProblem>} */
 		const problems = [];
+		/** @type {Array<{config:{rules:RulesConfig},loc:SourceLocation}>} */
 		const configs = [];
 
 		this.getInlineConfigNodes().forEach(comment => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hi,

In this PR, I've added missing type annotations to variables.

Adding type annotations helps improve type safety, and I noticed that some variables were missing them, so I went ahead and added the necessary annotations.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
