### PR TITLE
chore: add `.c8rc` file

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,0 +1,5 @@
+{
+	"include": ["src/**/*.js"],
+	"reporter": ["lcov", "text-summary", "cobertura"],
+	"sourceMap": true
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,12 @@ const eslintPluginTestsRecommendedConfig =
 //-----------------------------------------------------------------------------
 
 export default defineConfig([
-	globalIgnores(["**/tests/fixtures/", "**/dist/"]),
+	globalIgnores([
+		"**/tests/fixtures/",
+		"**/dist/",
+		"coverage/",
+		"src/build/",
+	]),
 
 	...eslintConfigESLint.map(config => ({
 		files: ["**/*.js"],
@@ -38,8 +43,7 @@ export default defineConfig([
 	})),
 	{
 		plugins: { json },
-		files: ["**/*.json"],
-		ignores: ["**/package-lock.json"],
+		files: ["**/*.json", ".c8rc"],
 		language: "json/json",
 		extends: ["json/recommended"],
 	},

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "test": "mocha tests/**/*.js",
-    "test:jsr": "npx jsr@latest publish --dry-run",
     "test:coverage": "c8 npm test",
+    "test:jsr": "npx jsr@latest publish --dry-run",
     "test:types": "tsc -p tests/types/tsconfig.json"
   },
   "keywords": [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request add a `.c8rc` similar to the one in `eslint/eslint` or `eslint/rewrite`. When `npm run test:coverage` is run, coverage reports will be generated in the `coverage` folder that can be used to find parts of code that are not covered by unit tests.

#### What changes did you make? (Give an overview)

* Added `.c8rc` file
* Updated ESLint config to make sure that the `.c8rc` file is linted as JSON, and to ignore the `coverage` folder.
* Also added a missing global ignores entry for `src/build/`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
