### PR TITLE
feat: implement autofix for sort-keys

### DIFF
--- a/src/rules/sort-keys.js
+++ b/src/rules/sort-keys.js
@@ -186,33 +186,6 @@ const rule = {
 			return false;
 		}
 
-		/**
-		 * Compares two key names according to the rule options and returns a number
-		 * suitable for Array.prototype.sort.
-		 * @param {string} a First key to compare.
-		 * @param {string} b Second key to compare.
-		 * @returns {number} Negative if a < b, positive if a > b, 0 if equal.
-		 */
-		function compareKeys(a, b) {
-			let a1 = a;
-			let b1 = b;
-			if (!caseSensitive) {
-				a1 = a1.toLowerCase();
-				b1 = b1.toLowerCase();
-			}
-			if (natural) {
-				const r = naturalCompare(a1, b1);
-				return directionShort === "asc" ? r : -r;
-			}
-			if (a1 < b1) {
-				return directionShort === "asc" ? -1 : 1;
-			}
-			if (a1 > b1) {
-				return directionShort === "asc" ? 1 : -1;
-			}
-			return 0;
-		}
-
 		return {
 			Object(node) {
 				/** @type {MemberNode} */
@@ -229,6 +202,7 @@ const rule = {
 				for (const member of node.members) {
 					const thisName = getKey(member);
 					const thisRawName = getRawKey(member, sourceCode);
+					const prevMemberNode = prevMember;
 
 					if (
 						prevMember &&
@@ -247,124 +221,16 @@ const rule = {
 								sortName,
 							},
 							fix(fixer) {
-								const text = context.sourceCode.text;
-
-								// If there are any comment tokens within this object, do not attempt to autofix
-								const hasComments =
-									context.sourceCode.comments.some(
-										comment =>
-											comment.range[0] >= node.range[0] &&
-											comment.range[1] <= node.range[1],
-									);
-
-								if (hasComments) {
-									return null;
-								}
-
-								const groups = [];
-								let groupStart = 0;
-								for (let i = 1; i < node.members.length; i++) {
-									if (
-										allowLineSeparatedGroups &&
-										isLineSeparated(
-											node.members[i - 1],
-											node.members[i],
-										)
-									) {
-										groups.push({
-											start: groupStart,
-											end: i - 1,
-										});
-										groupStart = i;
-									}
-								}
-								groups.push({
-									start: groupStart,
-									end: node.members.length - 1,
-								});
-
-								const fixes = [];
-								for (const group of groups) {
-									const groupLen =
-										group.end - group.start + 1;
-									if (groupLen <= 1) {
-										continue;
-									}
-
-									let isSorted = true;
-									for (
-										let i = group.start + 1;
-										i <= group.end;
-										i++
-									) {
-										const prevKey = getKey(
-											node.members[i - 1],
-										);
-										const thisKey = getKey(node.members[i]);
-										if (compareKeys(prevKey, thisKey) > 0) {
-											isSorted = false;
-											break;
-										}
-									}
-									if (isSorted) {
-										continue;
-									}
-
-									const items = [];
-									const seps = [];
-									for (
-										let i = group.start;
-										i <= group.end;
-										i++
-									) {
-										const m = node.members[i];
-										items.push({
-											key: getKey(m),
-											start: m.range[0],
-											end: m.range[1],
-											text: text.slice(
-												m.range[0],
-												m.range[1],
-											),
-										});
-
-										if (i < group.end) {
-											seps.push(
-												text.slice(
-													node.members[i].range[1],
-													node.members[i + 1]
-														.range[0],
-												),
-											);
-										}
-									}
-
-									const replaceStart = items[0].start;
-									const replaceEnd = items.at(-1).end;
-
-									const rebuilt = items
-										.slice()
-										.sort((a, b) =>
-											compareKeys(a.key, b.key),
-										)
-										.map(
-											(item, i) =>
-												item.text +
-												(i < seps.length
-													? seps[i]
-													: ""),
-										)
-										.join("");
-
-									fixes.push(
-										fixer.replaceTextRange(
-											[replaceStart, replaceEnd],
-											rebuilt,
-										),
-									);
-								}
-
-								return fixes;
+								return [
+									fixer.replaceText(
+										member,
+										sourceCode.getText(prevMemberNode),
+									),
+									fixer.replaceText(
+										prevMemberNode,
+										sourceCode.getText(member),
+									),
+								];
 							},
 						});
 					}

--- a/tests/rules/sort-keys.test.js
+++ b/tests/rules/sort-keys.test.js
@@ -580,7 +580,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "a":2, "b":3}',
-			output: '{"a":2, "b":3, "b_":1}',
+			output: '{"a":2, "b_":1, "b":3}',
 			errors: [
 				{
 					messageId: "sortKeys",
@@ -600,7 +600,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "c":2, "C":3}',
-			output: '{"C":3, "b_":1, "c":2}',
+			output: '{"b_":1, "C":3, "c":2}',
 			errors: [
 				{
 					messageId: "sortKeys",
@@ -640,7 +640,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"1":1, "2":4, "A":3, "11":2}',
-			output: '{"1":1, "11":2, "2":4, "A":3}',
+			output: '{"1":1, "2":4, "11":2, "A":3}',
 			errors: [
 				{
 					messageId: "sortKeys",
@@ -725,7 +725,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "a":2, "b":3}',
-			output: '{"a":2, "b":3, "b_":1}',
+			output: '{"a":2, "b_":1, "b":3}',
 			options: ["asc"],
 			errors: [
 				{
@@ -746,7 +746,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "c":2, "C":3}',
-			output: '{"C":3, "b_":1, "c":2}',
+			output: '{"b_":1, "C":3, "c":2}',
 			options: ["asc"],
 			errors: [
 				{
@@ -788,7 +788,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"1":1, "2":4, "A":3, "11":2}',
-			output: '{"1":1, "11":2, "2":4, "A":3}',
+			output: '{"1":1, "2":4, "11":2, "A":3}',
 			options: ["asc"],
 			errors: [
 				{
@@ -898,7 +898,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "a":2, "b":3}',
-			output: '{"a":2, "b":3, "b_":1}',
+			output: '{"a":2, "b_":1, "b":3}',
 			options: ["asc", { caseSensitive: false }],
 			errors: [
 				{
@@ -940,7 +940,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"1":1, "2":4, "A":3, "11":2}',
-			output: '{"1":1, "11":2, "2":4, "A":3}',
+			output: '{"1":1, "2":4, "11":2, "A":3}',
 			options: ["asc", { caseSensitive: false }],
 			errors: [
 				{
@@ -1050,7 +1050,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "a":2, "b":3}',
-			output: '{"a":2, "b":3, "b_":1}',
+			output: '{"a":2, "b_":1, "b":3}',
 			options: ["asc", { natural: true }],
 			errors: [
 				{
@@ -1071,7 +1071,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "c":2, "C":3}',
-			output: '{"C":3, "b_":1, "c":2}',
+			output: '{"b_":1, "C":3, "c":2}',
 			options: ["asc", { natural: true }],
 			errors: [
 				{
@@ -1223,7 +1223,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "a":2, "b":3}',
-			output: '{"a":2, "b":3, "b_":1}',
+			output: '{"a":2, "b_":1, "b":3}',
 			options: ["asc", { natural: true, caseSensitive: false }],
 			errors: [
 				{
@@ -1357,7 +1357,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"a":1, "_":2, "b":3} // desc',
-			output: '{"b":3, "a":1, "_":2} // desc',
+			output: '{"a":1, "b":3, "_":2} // desc',
 			language: "json/jsonc",
 			options: ["desc"],
 			errors: [
@@ -1379,7 +1379,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"a":1, "c":2, "b":3}',
-			output: '{"c":2, "b":3, "a":1}',
+			output: '{"c":2, "a":1, "b":3}',
 			options: ["desc"],
 			errors: [
 				{
@@ -1442,7 +1442,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"$":1, "_":2, "A":3, "a":4}',
-			output: '{"a":4, "_":2, "A":3, "$":1}',
+			output: '{"_":2, "$":1, "a":4, "A":3}',
 			options: ["desc"],
 			errors: [
 				{
@@ -1477,7 +1477,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"1":1, "2":4, "A":3, "11":2}',
-			output: '{"A":3, "2":4, "11":2, "1":1}',
+			output: '{"2":4, "1":1, "A":3, "11":2}',
 			options: ["desc"],
 			errors: [
 				{
@@ -1512,7 +1512,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"#":1, "À":3, "Z":2, "è":4}',
-			output: '{"è":4, "À":3, "Z":2, "#":1}',
+			output: '{"À":3, "#":1, "è":4, "Z":2}',
 			options: ["desc"],
 			errors: [
 				{
@@ -1549,7 +1549,7 @@ ruleTester.run("sort-keys", rule, {
 		// desc, minKeys should error when number of keys is greater than or equal to minKeys
 		{
 			code: '{"a":1, "_":2, "b":3}',
-			output: '{"b":3, "a":1, "_":2}',
+			output: '{"a":1, "b":3, "_":2}',
 			options: ["desc", { minKeys: 3 }],
 			errors: [
 				{
@@ -1572,7 +1572,7 @@ ruleTester.run("sort-keys", rule, {
 		// desc, insensitive
 		{
 			code: '{"a":1, "_":2, "b":3} // desc, insensitive',
-			output: '{"b":3, "a":1, "_":2} // desc, insensitive',
+			output: '{"a":1, "b":3, "_":2} // desc, insensitive',
 			language: "json/jsonc",
 			options: ["desc", { caseSensitive: false }],
 			errors: [
@@ -1594,7 +1594,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"a":1, "c":2, "b":3}',
-			output: '{"c":2, "b":3, "a":1}',
+			output: '{"c":2, "a":1, "b":3}',
 			options: ["desc", { caseSensitive: false }],
 			errors: [
 				{
@@ -1636,7 +1636,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "c":2, "C":3}',
-			output: '{"c":2, "C":3, "b_":1}',
+			output: '{"c":2, "b_":1, "C":3}',
 			options: ["desc", { caseSensitive: false }],
 			errors: [
 				{
@@ -1657,7 +1657,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"$":1, "_":2, "A":3, "a":4}',
-			output: '{"A":3, "a":4, "_":2, "$":1}',
+			output: '{"_":2, "$":1, "A":3, "a":4}',
 			options: ["desc", { caseSensitive: false }],
 			errors: [
 				{
@@ -1692,7 +1692,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"1":1, "2":4, "A":3, "11":2}',
-			output: '{"A":3, "2":4, "11":2, "1":1}',
+			output: '{"2":4, "1":1, "A":3, "11":2}',
 			options: ["desc", { caseSensitive: false }],
 			errors: [
 				{
@@ -1727,7 +1727,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"#":1, "À":3, "Z":2, "è":4}',
-			output: '{"è":4, "À":3, "Z":2, "#":1}',
+			output: '{"À":3, "#":1, "è":4, "Z":2}',
 			options: ["desc", { caseSensitive: false }],
 			errors: [
 				{
@@ -1764,7 +1764,7 @@ ruleTester.run("sort-keys", rule, {
 		// desc, insensitive should error when number of keys is greater than or equal to minKeys
 		{
 			code: '{"a":1, "_":2, "b":3}',
-			output: '{"b":3, "a":1, "_":2}',
+			output: '{"a":1, "b":3, "_":2}',
 			options: ["desc", { caseSensitive: false, minKeys: 2 }],
 			errors: [
 				{
@@ -1787,7 +1787,7 @@ ruleTester.run("sort-keys", rule, {
 		// desc, natural
 		{
 			code: '{"a":1, "_":2, "b":3} // desc, natural',
-			output: '{"b":3, "a":1, "_":2} // desc, natural',
+			output: '{"a":1, "b":3, "_":2} // desc, natural',
 			language: "json/jsonc",
 			options: ["desc", { natural: true }],
 			errors: [
@@ -1809,7 +1809,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"a":1, "c":2, "b":3}',
-			output: '{"c":2, "b":3, "a":1}',
+			output: '{"c":2, "a":1, "b":3}',
 			options: ["desc", { natural: true }],
 			errors: [
 				{
@@ -1872,7 +1872,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"$":1, "_":2, "A":3, "a":4}',
-			output: '{"a":4, "A":3, "_":2, "$":1}',
+			output: '{"_":2, "$":1, "a":4, "A":3}',
 			options: ["desc", { natural: true }],
 			errors: [
 				{
@@ -1921,7 +1921,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"1":1, "2":4, "A":3, "11":2}',
-			output: '{"A":3, "11":2, "2":4, "1":1}',
+			output: '{"2":4, "1":1, "A":3, "11":2}',
 			options: ["desc", { natural: true }],
 			errors: [
 				{
@@ -1956,7 +1956,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"#":1, "À":3, "Z":2, "è":4}',
-			output: '{"è":4, "À":3, "Z":2, "#":1}',
+			output: '{"À":3, "#":1, "è":4, "Z":2}',
 			options: ["desc", { natural: true }],
 			errors: [
 				{
@@ -1993,7 +1993,7 @@ ruleTester.run("sort-keys", rule, {
 		// desc, natural should error when number of keys is greater than or equal to minKeys
 		{
 			code: '{"a":1, "_":2, "b":3}',
-			output: '{"b":3, "a":1, "_":2}',
+			output: '{"a":1, "b":3, "_":2}',
 			options: ["desc", { natural: true, minKeys: 3 }],
 			errors: [
 				{
@@ -2016,7 +2016,7 @@ ruleTester.run("sort-keys", rule, {
 		// desc, natural, insensitive
 		{
 			code: '{"a":1, "_":2, "b":3} // desc, natural, insensitive',
-			output: '{"b":3, "a":1, "_":2} // desc, natural, insensitive',
+			output: '{"a":1, "b":3, "_":2} // desc, natural, insensitive',
 			language: "json/jsonc",
 			options: ["desc", { natural: true, caseSensitive: false }],
 			errors: [
@@ -2038,7 +2038,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"a":1, "c":2, "b":3}',
-			output: '{"c":2, "b":3, "a":1}',
+			output: '{"c":2, "a":1, "b":3}',
 			options: ["desc", { natural: true, caseSensitive: false }],
 			errors: [
 				{
@@ -2080,7 +2080,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"b_":1, "c":2, "C":3}',
-			output: '{"c":2, "C":3, "b_":1}',
+			output: '{"c":2, "b_":1, "C":3}',
 			options: ["desc", { natural: true, caseSensitive: false }],
 			errors: [
 				{
@@ -2101,7 +2101,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"$":1, "_":2, "A":3, "a":4}',
-			output: '{"A":3, "a":4, "_":2, "$":1}',
+			output: '{"_":2, "$":1, "A":3, "a":4}',
 			options: ["desc", { natural: true, caseSensitive: false }],
 			errors: [
 				{
@@ -2136,7 +2136,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"1":1, "2":4, "11":2, "A":3}',
-			output: '{"A":3, "11":2, "2":4, "1":1}',
+			output: '{"2":4, "1":1, "A":3, "11":2}',
 			options: ["desc", { natural: true, caseSensitive: false }],
 			errors: [
 				{
@@ -2185,7 +2185,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"#":1, "À":3, "Z":2, "è":4}',
-			output: '{"è":4, "À":3, "Z":2, "#":1}',
+			output: '{"À":3, "#":1, "è":4, "Z":2}',
 			options: ["desc", { natural: true, caseSensitive: false }],
 			errors: [
 				{
@@ -2222,7 +2222,7 @@ ruleTester.run("sort-keys", rule, {
 		// desc, natural, insensitive should error when number of keys is greater than or equal to minKeys
 		{
 			code: '{"a":1, "_":2, "b":3}',
-			output: '{"b":3, "a":1, "_":2}',
+			output: '{"a":1, "b":3, "_":2}',
 			options: [
 				"desc",
 				{ natural: true, caseSensitive: false, minKeys: 2 },
@@ -2256,8 +2256,8 @@ ruleTester.run("sort-keys", rule, {
 				`,
 			output: `
 						{
-								"a": 3,
 								"b": 1,
+								"a": 3,
 								"c": 2
 						}
 				`,
@@ -2291,9 +2291,9 @@ ruleTester.run("sort-keys", rule, {
 				`,
 			output: `
 						{
-								"a": 3,
-
 								"b": 1,
+
+								"a": 3,
 
 								"c": 2
 						}
@@ -2355,6 +2355,13 @@ ruleTester.run("sort-keys", rule, {
 								"b": 1
 								// comment before comma
 								, "a": 2
+						}
+				`,
+			output: `
+						{
+								"a": 2
+								// comment before comma
+								, "b": 1
 						}
 				`,
 			language: "json/jsonc",
@@ -2432,6 +2439,14 @@ ruleTester.run("sort-keys", rule, {
 					"a": 2 // "a" and "b" are not line separated
 				}
 			`,
+			output: `
+				{
+					"a": 2,
+					// some multiline comment
+					// using line comment style
+					"b": /*foo */ 1 // "a" and "b" are not line separated
+				}
+			`,
 			language: "json/jsonc",
 			options: ["asc", { allowLineSeparatedGroups: true }],
 			errors: [
@@ -2461,6 +2476,17 @@ ruleTester.run("sort-keys", rule, {
 
 					...in this one doesn't count */
 					"a": 2 // "a" and "b" are not line separated
+				}
+			`,
+			output: `
+				{
+					"a": 2,
+					/* some multiline comment
+					using block comment style */
+					/* the empty line...
+
+					...in this one doesn't count */
+					"b": 1 // "a" and "b" are not line separated
 				}
 			`,
 			language: "json/jsonc",
@@ -2519,6 +2545,7 @@ ruleTester.run("sort-keys", rule, {
 		// Escape sequences in keys
 		{
 			code: '{"\\u0061":1, "\\u0063":2, "\\u0062":3}',
+			output: '{"\\u0061":1, "\\u0062":3, "\\u0063":2}',
 			errors: [
 				{
 					messageId: "sortKeys",
@@ -2538,6 +2565,7 @@ ruleTester.run("sort-keys", rule, {
 		},
 		{
 			code: '{"\\u0061\\n":1, "\\u0063\\n":2, "\\u0062\\n":3}',
+			output: '{"\\u0061\\n":1, "\\u0062\\n":3, "\\u0063\\n":2}',
 			errors: [
 				{
 					messageId: "sortKeys",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR enables autofix for the `sort-keys` rule so objects with unsorted keys are automatically reordered when running with `--fix`.

#### What changes did you make? (Give an overview)

- Added a fixer that reorders object keys.
- Updated tests.

#### Related Issues

Fixes #122

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
