### PR TITLE
chore: add `concurrency` option to `eslint` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --fix",
+      "eslint --fix --concurrency auto",
       "prettier --write"
     ],
     "!(*.js)": "prettier --write --ignore-unknown",
@@ -66,7 +66,7 @@
     "build:update-rules-docs": "node tools/update-rules-docs.js",
     "prepare": "npm run build",
     "pretest": "npm run build",
-    "lint": "eslint",
+    "lint": "eslint --concurrency auto",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "test": "mocha tests/**/*.js",
@@ -91,7 +91,7 @@
   "devDependencies": {
     "c8": "^10.1.3",
     "dedent": "^1.5.3",
-    "eslint": "^9.31.0",
+    "eslint": "^9.34.0",
     "eslint-config-eslint": "^12.0.0",
     "eslint-plugin-eslint-plugin": "^6.3.2",
     "got": "^14.4.2",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've added a `concurrency` option to the `eslint` command.

I tested the speed of multithreaded linting on a public GitHub Actions runner and found that `--concurrency 2` and `--concurrency auto` were the fastest options (test results were based on the `eslint/eslint` repository):

Reference: https://github.com/eslint/eslint/issues/20026

<img width="840" height="533" alt="image" src="https://github.com/user-attachments/assets/1fd88e9e-a73d-47c7-99eb-f3a2252289db" />

<img width="834" height="784" alt="image" src="https://github.com/user-attachments/assets/5f9512a8-0756-449e-b8af-7dd4b2281976" />

Since `eslint/json` doesn't contain much JavaScript, linting speed doesn't differ much, but the codebase may grow and we've introduced a new feature, so I think integrating it into our codebase would be worthwhile.

#### What changes did you make? (Give an overview)

In this PR, I've added a `concurrency` option to the `eslint` command.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

I've been considering whether `--concurrency 2` or `--concurrency auto` is more appropriate, and since local development environments vary and the results from https://github.com/eslint/eslint/pull/19794 indicate that `auto` performs well in most environments, I've chosen `auto` in this case.

If there are any other suggestions, I'd be happy to hear them.
