### PR TITLE
refactor: use `defaultOptions` in `no-unnormalized-keys`

### DIFF
--- a/src/rules/no-unnormalized-keys.js
+++ b/src/rules/no-unnormalized-keys.js
@@ -45,12 +45,16 @@ const rule = {
 				additionalProperties: false,
 			},
 		],
+
+		defaultOptions: [
+			{
+				form: "NFC",
+			},
+		],
 	},
 
 	create(context) {
-		const form = context.options.length
-			? context.options[0].form
-			: undefined;
+		const [{ form }] = context.options;
 
 		return {
 			Member(node) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've updated the `no-unnormlized-keys` rule to use `defaultOptions`.

Previously, the rule used custom logic to extract its default value.

According to MDN and `@types/node`, the default value for `String.prototype.normalize` is `"NFC"`, so I've set it as the default.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#parameters

<img width="796" height="117" alt="image" src="https://github.com/user-attachments/assets/5c27fdbc-2de1-4bd6-8977-3467ca1849a9" />

<img width="943" height="83" alt="image" src="https://github.com/user-attachments/assets/f8a3fa1e-b42e-4626-a293-98209afc527f" />

#### What changes did you make? (Give an overview)

I've updated the `no-unnormlized-keys` rule to use `defaultOptions`.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
