### PR TITLE
test: add missing `json/jsonc` tests for rules

### DIFF
--- a/tests/rules/no-duplicate-keys.test.js
+++ b/tests/rules/no-duplicate-keys.test.js
@@ -31,6 +31,10 @@ ruleTester.run("no-duplicate-keys", rule, {
 		'{"foo": 1, "bar": {"bar": 2}}',
 		'{"foo": { "bar": 5 }, "bar": 6 }',
 		{
+			code: '{"foo": 1, "bar": {"bar": 2}}',
+			language: "json/jsonc",
+		},
+		{
 			code: "{foo: 1, bar: {bar: 2}}",
 			language: "json/json5",
 		},
@@ -64,6 +68,20 @@ ruleTester.run("no-duplicate-keys", rule, {
 					column: 5,
 					endLine: 5,
 					endColumn: 10,
+				},
+			],
+		},
+		{
+			code: '{"foo": 1, "foo": 2}',
+			language: "json/jsonc",
+			errors: [
+				{
+					messageId: "duplicateKey",
+					data: { key: "foo" },
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 17,
 				},
 			],
 		},

--- a/tests/rules/no-empty-keys.test.js
+++ b/tests/rules/no-empty-keys.test.js
@@ -27,6 +27,10 @@ ruleTester.run("no-empty-keys", rule, {
 		'{"foo": 1, "bar": 2}',
 		{
 			code: '{"foo": 1, "bar": 2, "baz": 3}',
+			language: "json/jsonc",
+		},
+		{
+			code: '{"foo": 1, "bar": 2, "baz": 3}',
 			language: "json/json5",
 		},
 		{
@@ -49,6 +53,32 @@ ruleTester.run("no-empty-keys", rule, {
 		},
 		{
 			code: '{"  ": 1}',
+			errors: [
+				{
+					messageId: "emptyKey",
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 6,
+				},
+			],
+		},
+		{
+			code: '{"": 1}',
+			language: "json/jsonc",
+			errors: [
+				{
+					messageId: "emptyKey",
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 4,
+				},
+			],
+		},
+		{
+			code: '{"  ": 1}',
+			language: "json/jsonc",
 			errors: [
 				{
 					messageId: "emptyKey",

--- a/tests/rules/no-unnormalized-keys.test.js
+++ b/tests/rules/no-unnormalized-keys.test.js
@@ -59,6 +59,20 @@ ruleTester.run("no-unnormalized-keys", rule, {
 			],
 		},
 		{
+			code: `{"${o.normalize("NFD")}":"NFD"}`,
+			language: "json/jsonc",
+			errors: [
+				{
+					messageId: "unnormalizedKey",
+					data: { key: o.normalize("NFD") },
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 7,
+				},
+			],
+		},
+		{
 			code: `{${o.normalize("NFD")}:"NFD"}`,
 			language: "json/json5",
 			errors: [

--- a/tests/rules/top-level-interop.test.js
+++ b/tests/rules/top-level-interop.test.js
@@ -25,6 +25,16 @@ const ruleTester = new RuleTester({
 ruleTester.run("top-level-interop", rule, {
 	valid: [
 		"[]",
+		"[1]",
+		"[1, 2]",
+		{
+			code: "[1]",
+			language: "json/jsonc",
+		},
+		{
+			code: "[1, 2]",
+			language: "json/jsonc",
+		},
 		{
 			code: "[1]",
 			language: "json/json5",
@@ -34,6 +44,16 @@ ruleTester.run("top-level-interop", rule, {
 			language: "json/json5",
 		},
 		"{}",
+		'{"foo": 1}',
+		'{"foo": 1, "foo": 2}',
+		{
+			code: '{"foo": 1}',
+			language: "json/jsonc",
+		},
+		{
+			code: '{"foo": 1, "foo": 2}',
+			language: "json/jsonc",
+		},
 		{
 			code: '{"foo": 1}',
 			language: "json/json5",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've added missing `json/jsonc` tests for rules.

Some rules already have dedicated tests for `json` and `json5`, but were missing `jsonc` tests. So, I've added those as well.

I've also included additional test cases in `top-level-interop`, which I believe will help improve consistency across the tests.

#### What changes did you make? (Give an overview)

I've added missing `json/jsonc` tests for rules.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A