### PR TITLE
feat: implement autofix for `no-unnormalized-keys`

### DIFF
--- a/src/rules/no-unnormalized-keys.js
+++ b/src/rules/no-unnormalized-keys.js
@@ -79,6 +79,11 @@ const rule = {
 							key: rawKey,
 						},
 						fix(fixer) {
+							if (key !== rawKey) {
+								// Do not perform auto-fix when the raw key contains escape sequences.
+								return null;
+							}
+
 							return fixer.replaceTextRange(
 								name.type === "String"
 									? [name.range[0] + 1, name.range[1] - 1]

--- a/tests/rules/no-unnormalized-keys.test.js
+++ b/tests/rules/no-unnormalized-keys.test.js
@@ -262,8 +262,38 @@ ruleTester.run("no-unnormalized-keys", rule, {
 		},
 		// escaped form
 		{
+			code: `{"${escapedNfcO}":"NFC"}`,
+			// No auto-fix due to the presence of escape sequences in the raw key.
+			options: [{ form: "NFD" }],
+			errors: [
+				{
+					messageId: "unnormalizedKey",
+					data: { key: escapedNfcO },
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 16,
+				},
+			],
+		},
+		{
+			code: `{"${escapedNfcO}\\n":42}`,
+			// No auto-fix due to the presence of escape sequences in the raw key.
+			options: [{ form: "NFD" }],
+			errors: [
+				{
+					messageId: "unnormalizedKey",
+					data: { key: `${escapedNfcO}\\n` },
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 18,
+				},
+			],
+		},
+		{
 			code: `{"${escapedNfdO}":"NFD"}`,
-			output: `{"${o.normalize("NFC")}":"NFD"}`,
+			// No auto-fix due to the presence of escape sequences in the raw key.
 			errors: [
 				{
 					messageId: "unnormalizedKey",
@@ -277,7 +307,7 @@ ruleTester.run("no-unnormalized-keys", rule, {
 		},
 		{
 			code: `{"${escapedNfkcO}":"NFKC"}`,
-			output: `{"${o.normalize("NFKD")}":"NFKC"}`,
+			// No auto-fix due to the presence of escape sequences in the raw key.
 			options: [{ form: "NFKD" }],
 			errors: [
 				{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've implemented an autofix for `no-unnormalized-keys`.

This PR closes #141.

## What changes did you make? (Give an overview)

In this PR, I've implemented an autofix for `no-unnormalized-keys`.

## Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

Closes: #141 

## Is there anything you'd like reviewers to focus on?

N/A