### PR TITLE
chore: correct `include` pattern for test files in `tsconfig.json`

### DIFF
--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -9,5 +9,5 @@
     "erasableSyntaxOnly": true
   },
   "files": [],
-  "include": ["**/*.test.{ts,cts}", "../../dist"]
+  "include": ["**/*.test.ts", "**/*.test.cts", "../../dist"]
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've corrected `include` pattern for test files in `tsconfig.json`.

The current glob pattern with `{}` isn't supported by `tsconfig.json`.

As a result, intentionally failing a type test and running `npm run test:types` doesn't report type errors because `tsconfig.json` doesn't recognize that syntax.

Ref: https://www.typescriptlang.org/tsconfig/#include

<img width="584" height="147" alt="image" src="https://github.com/user-attachments/assets/b920853b-dfab-4967-969d-99d6def58ff1" />

#### What changes did you make? (Give an overview)

In this PR, I've corrected `include` pattern for test files in `tsconfig.json`.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A