### PR TITLE
fix: correct the return type of `applyInlineConfig`

### DIFF
--- a/src/languages/json-source-code.js
+++ b/src/languages/json-source-code.js
@@ -21,9 +21,10 @@ import {
 
 /**
  * @import { DocumentNode, AnyNode, Token } from "@humanwhocodes/momoa";
- * @import { SourceLocation, FileProblem, DirectiveType, RulesConfig } from "@eslint/core";
+ * @import { FileProblem, DirectiveType, RulesConfig } from "@eslint/core";
  * @import { JSONSyntaxElement } from "../types.ts";
  * @import { JSONLanguageOptions } from "./json-language.js";
+ * @typedef {Token['loc']} LocationRange
  */
 
 //-----------------------------------------------------------------------------
@@ -248,13 +249,13 @@ export class JSONSourceCode extends TextSourceCodeBase {
 	/**
 	 * Returns inline rule configurations along with any problems
 	 * encountered while parsing the configurations.
-	 * @returns {{problems:Array<FileProblem>,configs:Array<{config:{rules:RulesConfig},loc:SourceLocation}>}} Information
+	 * @returns {{problems:Array<FileProblem>,configs:Array<{config:{rules:RulesConfig},loc:LocationRange}>}} Information
 	 *      that ESLint needs to further process the rule configurations.
 	 */
 	applyInlineConfig() {
 		/** @type {Array<FileProblem>} */
 		const problems = [];
-		/** @type {Array<{config:{rules:RulesConfig},loc:SourceLocation}>} */
+		/** @type {Array<{config:{rules:RulesConfig},loc:LocationRange}>} */
 		const configs = [];
 
 		this.getInlineConfigNodes().forEach(comment => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

WIP

## What changes did you make? (Give an overview)

## Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?
