### PR TITLE
fix: handle CR in `JSONSourceCode`

### DIFF
--- a/src/languages/json-source-code.js
+++ b/src/languages/json-source-code.js
@@ -148,7 +148,7 @@ export class JSONSourceCode extends TextSourceCodeBase {
 	 * @param {DocumentNode} options.ast The root AST node.
 	 */
 	constructor({ text, ast }) {
-		super({ text, ast });
+		super({ text, ast, lineEndingPattern: /\r\n|[\r\n]/u });
 		this.ast = ast;
 
 		const { comments, starts, ends } = processTokens(this.ast.tokens ?? []);

--- a/tests/languages/json-source-code.test.js
+++ b/tests/languages/json-source-code.test.js
@@ -346,7 +346,7 @@ describe("JSONSourceCode", () => {
 	});
 
 	describe("lines", () => {
-		it("should return an array of lines", () => {
+		it("should split lines on LF line endings", () => {
 			const file = { body: "{\n//test\n}", path: "test.jsonc" };
 			const language = new JSONLanguage({ mode: "jsonc" });
 			const parseResult = language.parse(file);
@@ -356,6 +356,50 @@ describe("JSONSourceCode", () => {
 			});
 
 			assert.deepStrictEqual(sourceCode.lines, ["{", "//test", "}"]);
+		});
+
+		it("should split lines on CR line endings", () => {
+			const file = { body: "{\r//test\r}", path: "test.jsonc" };
+			const language = new JSONLanguage({ mode: "jsonc" });
+			const parseResult = language.parse(file);
+			const sourceCode = new JSONSourceCode({
+				text: file.body,
+				ast: parseResult.ast,
+			});
+
+			assert.deepStrictEqual(sourceCode.lines, ["{", "//test", "}"]);
+		});
+
+		it("should split lines on CRLF line endings", () => {
+			const file = { body: "{\r\n//test\r\n}", path: "test.jsonc" };
+			const language = new JSONLanguage({ mode: "jsonc" });
+			const parseResult = language.parse(file);
+			const sourceCode = new JSONSourceCode({
+				text: file.body,
+				ast: parseResult.ast,
+			});
+
+			assert.deepStrictEqual(sourceCode.lines, ["{", "//test", "}"]);
+		});
+
+		it("should split lines with mixed line endings (LF, CRLF, CR)", () => {
+			const file = {
+				body: "{\n//one\r\n//two\r}",
+				path: "test.jsonc",
+			};
+			const language = new JSONLanguage({ mode: "jsonc" });
+			const parseResult = language.parse(file);
+			const sourceCode = new JSONSourceCode({
+				text: file.body,
+				ast: parseResult.ast,
+			});
+
+			assert.deepStrictEqual(sourceCode.lines, [
+				"{",
+				"//one",
+				"//two",
+				"}",
+			]);
 		});
 	});
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes a bug in `JSONSourceCode` where carriage return (`\r`) characters were not recognized as line breaks.

#### What changes did you make? (Give an overview)

- Update `JSONSourceCode` to recognize CR line endings.
- Added tests to verify correct behavior for LF, CRLF, CR.

#### Related Issues

Fixes #159

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
