### PR TITLE
docs: add missing `json5` language to the `bug-report.yml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -29,6 +29,7 @@ body:
           options:
               - json
               - jsonc
+              - json5
       validations:
           required: true
     - type: textarea


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've added missing `json5` language to the `bug-report.yml`.

- `json5` is missing:

<img width="343" height="218" alt="image" src="https://github.com/user-attachments/assets/e5887777-23e7-47f5-b78f-a800b0e9a4c6" />

#### What changes did you make? (Give an overview)

In this PR, I've added missing `json5` language to the `bug-report.yml`.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A