### PR TITLE
ci: add type tests for TypeScript 5.x to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
               run: npm install
             - name: Check Types
               run: npm run test:types
+            - name: Check Types (TypeScript 5.3)
+              run: npx -p typescript@5.3 -y -- tsc -p tests/types/tsconfig.dist.json
+            - name: Check Types (TypeScript 5.x)
+              run: npx -p typescript@5.x -y -- tsc -p tests/types/tsconfig.dist.json
     are_the_types_wrong:
         name: Are the types wrong?
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
             - name: Check Types
               run: npm run test:types
             - name: Check Types (TypeScript 5.3)
-              run: npx -p typescript@5.3 -y -- tsc -p tests/types/tsconfig.dist.json
+              run: npm run test:types:5.3
             - name: Check Types (TypeScript 5.x)
-              run: npx -p typescript@5.x -y -- tsc -p tests/types/tsconfig.dist.json
+              run: npm run test:types:5.x
     are_the_types_wrong:
         name: Are the types wrong?
         runs-on: ubuntu-latest

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -107,8 +107,9 @@ export default defineConfig([
 	{
 		name: "json/jsonc",
 		plugins: { json },
-		files: ["**/*.jsonc"],
+		files: ["**/*.jsonc", "**/tsconfig*.json"],
 		language: "json/jsonc",
+		languageOptions: { allowTrailingCommas: true },
 		extends: ["json/recommended"],
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "test:coverage": "c8 npm test",
     "test:jsr": "npx -y jsr@latest publish --dry-run",
     "test:types": "tsc -p tests/types/tsconfig.json",
-    "test:types:5.3": "npx -p typescript@5.3 -y -- tsc -p tests/types/tsconfig.dist.json",
-    "test:types:5.x": "npx -p typescript@5.x -y -- tsc -p tests/types/tsconfig.dist.json",
+    "test:types:5.3": "npx -p typescript@5.3 -y -- tsc -p tests/types/tsconfig.legacy.json",
+    "test:types:5.x": "npx -p typescript@5.x -y -- tsc -p tests/types/tsconfig.json",
     "test:types:all": "npm run test:types && npm run test:types:5.x && npm run test:types:5.3"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
     "test": "mocha \"tests/**/*.test.js\"",
     "test:coverage": "c8 npm test",
     "test:jsr": "npx -y jsr@latest publish --dry-run",
-    "test:types": "tsc -p tests/types/tsconfig.json"
+    "test:types": "tsc -p tests/types/tsconfig.json",
+    "test:types:5.3": "npx -p typescript@5.3 -y -- tsc -p tests/types/tsconfig.dist.json",
+    "test:types:5.x": "npx -p typescript@5.x -y -- tsc -p tests/types/tsconfig.dist.json",
+    "test:types:all": "npm run test:types && npm run test:types:5.x && npm run test:types:5.3"
   },
   "keywords": [
     "eslint",

--- a/tests/types/tsconfig.dist.json
+++ b/tests/types/tsconfig.dist.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "checkJs": false, // The JSDoc @import tag used in JS files is not supported in TypeScript < 5.5.
+    "noEmit": true,
+    "rootDir": "../..",
+    "strict": true,
+    "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true
+    // "erasableSyntaxOnly" is not supported in TypeScript < 5.8.
+  },
+  "files": [],
+  "include": ["../../dist"]
+}

--- a/tests/types/tsconfig.dist.json
+++ b/tests/types/tsconfig.dist.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": false,
     "checkJs": false, // The JSDoc @import tag used in JS files is not supported in TypeScript < 5.5.
     "noEmit": true,
     "rootDir": "../..",

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
     "noEmit": true,
     "rootDir": "../..",
     "strict": true,
@@ -11,5 +13,5 @@
     "erasableSyntaxOnly": true
   },
   "files": [],
-  "include": ["**/*.test.ts", "**/*.test.cts", "../../dist"]
+  "include": [".", "../../dist"]
 }

--- a/tests/types/tsconfig.legacy.json
+++ b/tests/types/tsconfig.legacy.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "allowJs": false,
-    "checkJs": false, // The JSDoc @import tag used in JS files is not supported in TypeScript < 5.5.
+    "checkJs": false,
     "noEmit": true,
     "rootDir": "../..",
     "strict": true,
@@ -13,5 +13,5 @@
     // "erasableSyntaxOnly" is not supported in TypeScript < 5.8.
   },
   "files": [],
-  "include": ["../../dist"]
+  "include": [".", "../../dist"]
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

add tests in CI

#### What changes did you make? (Give an overview)

Add type tests for TypeScript v5.3 and v.5.x besides existing tests targeting TypeScript v6.0.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

refs #224

#### Is there anything you'd like reviewers to focus on?
