### PR TITLE
docs: fix no-unsafe-values examples

### DIFF
--- a/docs/rules/no-unsafe-values.md
+++ b/docs/rules/no-unsafe-values.md
@@ -20,6 +20,8 @@ This rule warns on values that are unsafe for interchange, such as strings with 
 
 Examples of **incorrect** code for this rule:
 
+<!-- prettier-ignore-start -->
+
 ```jsonc
 /* eslint json/no-unsafe-values: "error" */
 
@@ -34,9 +36,11 @@ Examples of **incorrect** code for this rule:
 
 	9007199254740992, // Unsafe integer (outside safe integer range)
 
-	2.2250738585072009e-308, // Subnormal number
+	2.2250738585072009e-308 // Subnormal number
 ]
 ```
+
+<!-- prettier-ignore-end -->
 
 Examples of **correct** code for this rule:
 
@@ -55,8 +59,8 @@ Examples of **correct** code for this rule:
 	"\ud83d\udd25", // Same character with proper surrogate pair
 
 	0.00000,
-    	0e0000000,
-    	0.00000e0000 // Zero represented in different valid ways
+	0e0000000,
+	0.00000e0000 // Zero represented in different valid ways
 ]
 ```
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fix the `no-unsafe-values` rule documentation so its examples are valid and consistently formatted.

#### What changes did you make? (Give an overview)

- Removed a trailing comma from the incorrect jsonc example.
- Fixed indentation in the correct zero-value examples.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
