### PR TITLE
test: run type tests with TypeScript 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
               run: npm run test:types:5.3
             - name: Check Types (TypeScript 5.x)
               run: npm run test:types:5.x
+            - name: Check Types (TypeScript 7 preview)
+              run: npm run test:types:7.x
     are_the_types_wrong:
         name: Are the types wrong?
         runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "test:types": "tsc -p tests/types/tsconfig.json",
     "test:types:5.3": "npx -p typescript@5.3 -y -- tsc -p tests/types/tsconfig.legacy.json",
     "test:types:5.x": "npx -p typescript@5.x -y -- tsc -p tests/types/tsconfig.json",
-    "test:types:all": "npm run test:types && npm run test:types:5.x && npm run test:types:5.3"
+    "test:types:7.x": "npx -p @typescript/native-preview@latest -y -- tsgo -p tests/types/tsconfig.json",
+    "test:types:all": "npm run test:types && npm run test:types:5.3 && npm run test:types:5.x && npm run test:types:7.x"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR follows the same strategy from https://github.com/eslint/rewrite/pull/447.

This PR ensures that type tests are run in TypeScript 7 preview besides TypeScript 5.3, 5.x and 6.x.

#### What changes did you make? (Give an overview)

- Updated "Check Types" CI job
- Added npm script `test:types:7.x` and extended `test:types:all`

#### Related Issues

Ref: https://github.com/eslint/rewrite/pull/447

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A