### PR TITLE
refactor: safe fallback for regex groups in no-unsafe-values

### DIFF
--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -86,8 +86,8 @@ const rule = {
 						// non-zero digit in it, this number was not intended to be
 						// evaluated down to a zero.
 						if (
-							NON_ZERO.test(match.groups.int) ||
-							NON_ZERO.test(match.groups.frac)
+							NON_ZERO.test(match.groups.int ?? "") ||
+							NON_ZERO.test(match.groups.frac ?? "")
 						) {
 							context.report({
 								loc: node.loc,


### PR DESCRIPTION
Fixes #255

This PR safely coalesces the `int` and `frac` capture groups to an empty string (`""`) inside the `no-unsafe-values` rule before testing them with the `NON_ZERO` regex. 

This prevents JavaScript from implicitly coercing `undefined` into the string `"undefined"` when `RegExp.test()` is called with missing capture groups (e.g., when processing numbers like `.e-100` that omit the integer part).
