### PR TITLE
docs: add eslint to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This package contains a plugin that allows you to natively lint JSON, JSONC, and
 For Node.js and compatible runtimes:
 
 ```shell
-npm install @eslint/json -D
+npm install eslint @eslint/json -D
 # or
-yarn add @eslint/json -D
+yarn add eslint @eslint/json -D
 # or
-pnpm install @eslint/json -D
+pnpm install eslint @eslint/json -D
 # or
-bun add @eslint/json -D
+bun add eslint @eslint/json -D
 ```
 
 For Deno:

--- a/README.md
+++ b/README.md
@@ -8,16 +8,27 @@ This package contains a plugin that allows you to natively lint JSON, JSONC, and
 
 ## Installation
 
-For Node.js and compatible runtimes:
+You can install ESLint using npm or other package managers:
+```shell
+npm install eslint -D
+# or
+yarn add eslint -D
+# or
+pnpm install eslint -D
+# or
+bun add eslint -D
+```
+
+Then, for Node.js and compatible runtimes:
 
 ```shell
-npm install eslint @eslint/json -D
+npm install @eslint/json -D
 # or
-yarn add eslint @eslint/json -D
+yarn add @eslint/json -D
 # or
-pnpm install eslint @eslint/json -D
+pnpm install @eslint/json -D
 # or
-bun add eslint @eslint/json -D
+bun add @eslint/json -D
 ```
 
 For Deno:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This package contains a plugin that allows you to natively lint JSON, JSONC, and
 ## Installation
 
 You can install ESLint using npm or other package managers:
+
 ```shell
 npm install eslint -D
 # or


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Documentation update.

`@eslint/json` does not declare `eslint` as a peer dependency, so installing the plugin alone does not install ESLint. However, the install commands in the README only include `@eslint/json`, which may lead new users to miss the required `eslint` dependency. This PR updates the install commands to include `eslint` so users can get started without missing dependencies.


#### What changes did you make? (Give an overview)

Added `eslint` to the install commands in the README for npm, yarn, pnpm, and bun:

- `npm install @eslint/json -D` → `npm install eslint @eslint/json -D`
- `yarn add @eslint/json -D` → `yarn add eslint @eslint/json -D`
- `pnpm install @eslint/json -D` → `pnpm install eslint @eslint/json -D`
- `bun add @eslint/json -D` → `bun add eslint @eslint/json -D`


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
No.