### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -12,6 +12,9 @@ on:
             - opened
             - reopened
 
+permissions:
+  contents: read
+
 jobs:
     add-to-triage:
         uses: eslint/workflows/.github/workflows/add-to-triage.yml@main

--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -13,7 +13,7 @@ on:
             - reopened
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
     add-to-triage:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Explicitly declares `contents: read` permissions for the affected workflows instead of relying on the default `GITHUB_TOKEN` permissions.

Explicitly declares `permissions: contents: read` for workflows that only require read access instead of relying on the default `GITHUB_TOKEN` permissions.

Since the affected workflows only check out the repository and do not perform any write operations, this change follows the principle of least privilege and improves workflow security by reducing the permissions granted to the `GITHUB_TOKEN`.

#### What changes did you make? (Give an overview)

* Added explicit `permissions: contents: read` to the affected GitHub Actions workflows.
* Confirmed that the workflows only require read access to check out the repository and do not perform any write operations.
* Applied the same workflow permission hardening approach as [eslint/.github#20](https://github.com/eslint/.github/pull/20).


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
