### PR TITLE
docs: use blob URLs for rule documentation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,7 +71,7 @@ export default defineConfig([
 				"error",
 				{
 					pattern:
-						"https://github.com/eslint/json/tree/main/docs/rules/{{name}}.md",
+						"https://github.com/eslint/json/blob/main/docs/rules/{{name}}.md",
 				},
 			],
 		},

--- a/src/rules/no-duplicate-keys.js
+++ b/src/rules/no-duplicate-keys.js
@@ -33,7 +33,7 @@ export default /** @satisfies {NoDuplicateKeysRuleDefinition} */ ({
 			recommended: true,
 			description: "Disallow duplicate keys in JSON objects",
 			dialects: ["JSON", "JSONC", "JSON5"],
-			url: "https://github.com/eslint/json/tree/main/docs/rules/no-duplicate-keys.md",
+			url: "https://github.com/eslint/json/blob/main/docs/rules/no-duplicate-keys.md",
 		},
 
 		messages: {

--- a/src/rules/no-empty-keys.js
+++ b/src/rules/no-empty-keys.js
@@ -32,7 +32,7 @@ export default /** @satisfies {NoEmptyKeysRuleDefinition} */ ({
 			recommended: true,
 			description: "Disallow empty keys in JSON objects",
 			dialects: ["JSON", "JSONC", "JSON5"],
-			url: "https://github.com/eslint/json/tree/main/docs/rules/no-empty-keys.md",
+			url: "https://github.com/eslint/json/blob/main/docs/rules/no-empty-keys.md",
 		},
 
 		messages: {

--- a/src/rules/no-unnormalized-keys.js
+++ b/src/rules/no-unnormalized-keys.js
@@ -35,7 +35,7 @@ export default /** @satisfies {NoUnnormalizedKeysRuleDefinition} */ ({
 			recommended: true,
 			description: "Disallow JSON keys that are not normalized",
 			dialects: ["JSON", "JSONC", "JSON5"],
-			url: "https://github.com/eslint/json/tree/main/docs/rules/no-unnormalized-keys.md",
+			url: "https://github.com/eslint/json/blob/main/docs/rules/no-unnormalized-keys.md",
 		},
 
 		messages: {

--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -44,7 +44,7 @@ export default /** @satisfies {NoUnsafeValuesRuleDefinition} */ ({
 			recommended: true,
 			description: "Disallow JSON values that are unsafe for interchange",
 			dialects: ["JSON", "JSONC", "JSON5"],
-			url: "https://github.com/eslint/json/tree/main/docs/rules/no-unsafe-values.md",
+			url: "https://github.com/eslint/json/blob/main/docs/rules/no-unsafe-values.md",
 		},
 
 		messages: {

--- a/src/rules/sort-keys.js
+++ b/src/rules/sort-keys.js
@@ -96,7 +96,7 @@ export default /** @satisfies {SortKeysRuleDefinition} */ ({
 			recommended: false,
 			description: `Require JSON object keys to be sorted`,
 			dialects: ["JSON", "JSONC", "JSON5"],
-			url: "https://github.com/eslint/json/tree/main/docs/rules/sort-keys.md",
+			url: "https://github.com/eslint/json/blob/main/docs/rules/sort-keys.md",
 		},
 
 		messages: {

--- a/src/rules/top-level-interop.js
+++ b/src/rules/top-level-interop.js
@@ -27,7 +27,7 @@ export default /** @satisfies {TopLevelInteropRuleDefinition} */ ({
 			description:
 				"Require the JSON top-level value to be an array or object",
 			dialects: ["JSON", "JSONC", "JSON5"],
-			url: "https://github.com/eslint/json/tree/main/docs/rules/top-level-interop.md",
+			url: "https://github.com/eslint/json/blob/main/docs/rules/top-level-interop.md",
 		},
 
 		messages: {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR updates rule documentation links to use the correct GitHub URL format for files.

#### What changes did you make? (Give an overview)

Changed the rule `meta.docs.url` links from `tree/main` to `blob/main`, and updated the matching URL pattern in `eslint.config.js`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
