### PR TITLE
feat: treat hexadecimal literals as integers in `no-unsafe-values`

### DIFF
--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -30,6 +30,7 @@
 const NUMBER =
 	/^[+-]?(?<int>0|([1-9]\d*))?(?:\.(?<frac>\d*))?(?:e[+-]?\d+)?$/iu;
 const NON_ZERO = /[1-9]/u;
+const HEX = /^[+-]?0x/iu;
 
 //-----------------------------------------------------------------------------
 // Rule Definition
@@ -94,8 +95,8 @@ export default /** @satisfies {NoUnsafeValuesRuleDefinition} */ ({
 								data: { value },
 							});
 						}
-					} else if (!/[.e]/iu.test(value)) {
-						// Intended to be an integer
+					} else if (HEX.test(value) || !/[.e]/iu.test(value)) {
+						// Intended to be an integer; in hex, `e` is a digit, not an exponent
 						if (
 							node.value > Number.MAX_SAFE_INTEGER ||
 							node.value < Number.MIN_SAFE_INTEGER

--- a/tests/rules/no-unsafe-values.test.js
+++ b/tests/rules/no-unsafe-values.test.js
@@ -63,6 +63,10 @@ ruleTester.run("no-unsafe-values", rule, {
 			language: "json/json5",
 		},
 		{
+			code: "0xDEADBEEF",
+			language: "json/json5",
+		},
+		{
 			code: ".0",
 			language: "json/json5",
 		},
@@ -414,6 +418,86 @@ ruleTester.run("no-unsafe-values", rule, {
 					column: 1,
 					endLine: 1,
 					endColumn: 25,
+				},
+			],
+		},
+		{
+			code: "0xe0000000000000",
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "unsafeInteger",
+					data: {
+						value: "0xe0000000000000",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: "0XE0000000000000",
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "unsafeInteger",
+					data: {
+						value: "0XE0000000000000",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: "0xdeadbeefdeadbeef",
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "unsafeInteger",
+					data: {
+						value: "0xdeadbeefdeadbeef",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 19,
+				},
+			],
+		},
+		{
+			code: "+0xe0000000000000",
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "unsafeInteger",
+					data: {
+						value: "+0xe0000000000000",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 18,
+				},
+			],
+		},
+		{
+			code: "-0xe0000000000000",
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "unsafeInteger",
+					data: {
+						value: "-0xe0000000000000",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 18,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Bug fix.

#### What changes did you make? (Give an overview)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c311293e-cee8-49a9-a6c4-a55231fa274c" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/6fca576b-4e55-4051-b2df-c39dfd8fdfd4" />

`no-unsafe-values` decides whether a number was intended to be an integer by testing its raw text for `.` or `e`. In a hexadecimal literal, `e` and `E` are digits rather than an exponent marker, so any hexadecimal literal containing one of them was routed to the floating point branch, which only checks for subnormals. Those values were never compared against the safe integer range and nothing was reported.

Changes:

- Added a `HEX` pattern next to the existing `NUMBER` and `NON_ZERO` constants.
- The integer branch now also accepts hexadecimal literals, so they are always compared against `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER`.
- Extended the existing comment on that branch to say why hexadecimal is treated separately.

The source change is small: one new constant and one condition in the integer branch. Decimal notation is untouched: `1e10`, `1.5` and `0.00001e-10` still take the floating point branch exactly as before.

New test cases:

Invalid, previously not reported:

- `0xe0000000000000` (`63050394783186944`)
- `0XE0000000000000` (uppercase `E`)
- `0xdeadbeefdeadbeef` (`16045690984833335023`, which becomes `16045690984833335296` when read as a number)
- `+0xe0000000000000` and `-0xe0000000000000`

Valid, must stay unreported:

- `0xDEADBEEF` (`3735928559`, inside the safe integer range)

I checked that the new tests actually guard the change by reverting the source edit and running the suite again: exactly those five invalid cases fail without the fix and pass with it. The zero-valued hexadecimal cases added in #194 (`0x0`, `0X0`, `+0x0`, `+0X0`, `-0x0`, `-0X0`) are unaffected, since they are handled by the earlier `node.value === 0` branch.

`npm test` and `npm run lint` both pass.

#### Related Issues

fixes #266

#### Is there anything you'd like reviewers to focus on?

Two things about the test cases:

1. The `0xDEADBEEF` valid case is there on purpose. It is a hexadecimal literal that contains `E` but is inside the safe integer range, so it guards against over-correcting this into "report every hexadecimal literal".
2. `+0x…` and `-0x…` are included because #194 dealt with signed hexadecimal input, so I wanted the signed forms covered explicitly.
