### PR TITLE
chore: add yorkie to allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
   },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"
+  },
+  "allowScripts": {
+    "yorkie": true
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

I received assistance from Claude during the PR translation process.

#### What is the purpose of this pull request?

Add `yorkie` to the `allowScripts` field in `package.json` ahead of npm v12's upcoming security-related default changes.

#### What changes did you make? (Give an overview)
`npm install` shows the following warning because `yorkie` contains an install script:

```
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   yorkie@2.0.0 (install: node bin/install.js)
```
npm v12 will require dependency install scripts to be explicitly allowed through the `allowScripts` field. I reviewed the script and confirmed it only installs Git hooks, so it is safe to allow.

Therefore, I added `yorkie` to `allowScripts` in `package.json`. I also removed the version pin from the entry that `npm approve-scripts` generated, since this repository does not use a lockfile and does not pin dependency versions.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
