### PR TITLE
docs: clarify JSON5 `Infinity` and `NaN` handling in `no-unsafe-values`

### DIFF
--- a/src/rules/no-unsafe-values.js
+++ b/src/rules/no-unsafe-values.js
@@ -127,6 +127,15 @@ export default /** @satisfies {NoUnsafeValuesRuleDefinition} */ ({
 					}
 				}
 			},
+			Infinity(node) {
+				const value = context.sourceCode.getText(node);
+
+				context.report({
+					loc: node.loc,
+					messageId: "unsafeNumber",
+					data: { value },
+				});
+			},
 			String(node) {
 				if (node.value.isWellFormed) {
 					if (node.value.isWellFormed()) {

--- a/tests/rules/no-unsafe-values.test.js
+++ b/tests/rules/no-unsafe-values.test.js
@@ -107,6 +107,38 @@ ruleTester.run("no-unsafe-values", rule, {
 			],
 		},
 		{
+			code: "Infinity",
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "unsafeNumber",
+					data: {
+						value: "Infinity",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 9,
+				},
+			],
+		},
+		{
+			code: "-Infinity",
+			language: "json/json5",
+			errors: [
+				{
+					messageId: "unsafeNumber",
+					data: {
+						value: "-Infinity",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 10,
+				},
+			],
+		},
+		{
 			code: '"\ud83d"',
 			errors: [
 				{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fix `no-unsafe-values` not reporting JSON5 `Infinity` values.

#### What changes did you make? (Give an overview)

Added an `Infinity` visitor and regression tests for `Infinity` and `-Infinity`.

#### Related Issues

fixes #277 

#### Is there anything you'd like reviewers to focus on?

<img width="443" height="899" alt="image" src="https://github.com/user-attachments/assets/e086b899-1082-4acd-b58d-1db678452dcf" />

`+Infinity` is intentionally omitted to match the existing `2e308`/`-2e308` coverage (which does not include `+2e308`).

<hr />

Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that explicit JSON5 `Infinity` and `NaN` values are accepted by the `no-unsafe-values` rule.
  - Documented that numeric literals exceeding JavaScript’s number range remain subject to unsafe-value checks, even when they evaluate to `Infinity`.

- **Tests**
  - Added coverage confirming valid handling of signed and unsigned `Infinity` and `NaN` JSON5 literals.
  - Removed outdated expectations that reported explicit `Infinity` values as unsafe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->