### PR TITLE
fix: preserve parsing error locations in Bun

### DIFF
--- a/src/languages/json-language.js
+++ b/src/languages/json-language.js
@@ -143,6 +143,8 @@ export class JSONLanguage {
 				errors: [
 					{
 						...ex,
+						line: ex.line,
+						column: ex.column,
 						message,
 					},
 				],

--- a/tests/languages/json-language.test.js
+++ b/tests/languages/json-language.test.js
@@ -85,6 +85,8 @@ describe("JSONLanguage", () => {
 				result.errors[0].message,
 				"Unexpected character '/' found.",
 			);
+			assert.strictEqual(result.errors[0].line, 2);
+			assert.strictEqual(result.errors[0].column, 1);
 		});
 
 		it("should not parse trailing commas by default in json mode", () => {
@@ -99,6 +101,8 @@ describe("JSONLanguage", () => {
 				result.errors[0].message,
 				"Unexpected token RBrace found.",
 			);
+			assert.strictEqual(result.errors[0].line, 3);
+			assert.strictEqual(result.errors[0].column, 1);
 		});
 
 		it("should not parse trailing commas by default in jsonc mode", () => {
@@ -113,6 +117,8 @@ describe("JSONLanguage", () => {
 				result.errors[0].message,
 				"Unexpected token RBrace found.",
 			);
+			assert.strictEqual(result.errors[0].line, 3);
+			assert.strictEqual(result.errors[0].column, 1);
 		});
 
 		it("should parse trailing commas when enabled in jsonc mode", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

### Environment

- ESLint version: 10.7.0
- @eslint/json version: 2.1.0
- npm version: 11.16.0
- Bun version: 1.4.2
- Operating System: Windows x64

### Which language are you using?

json

### What did you do?

Install `eslint@10.7.0` and `@eslint/json@2.1.0`, then save this as `repro.mjs`:

```js
import { Linter } from "eslint";
import json from "@eslint/json";

const messages = new Linter().verify(
	"{\n//test\n}",
	[{ files: ["**/*.json"], plugins: { json }, language: "json/json" }],
	{ filename: "test.json" },
);
console.log(JSON.stringify(messages, null, 2));
```

Run `bun repro.mjs` and compare with `node repro.mjs`.

### What did you expect to happen?

The parsing error includes `line: 2` and `column: 1`, as it does in Node.js.

### What actually happened?

Bun omits both properties:

```json
[
	{
		"ruleId": null,
		"fatal": true,
		"severity": 2,
		"message": "Parsing error: Unexpected character '/' found."
	}
]
```

### Link to Minimal Reproducible Example

The standalone reproduction is included above. 

Related reproduction in CI: https://github.com/eslint/json/actions/runs/33971265538/job/101320084273?pr=281

## What changes did you make? (Give an overview)

In Bun, the parser error's `line` and `column` are non-enumerable, so `...ex` in `JSONLanguage.parse()` drops them. Explicitly copying `line: ex.line` and `column: ex.column` preserves the location.

## Related Issues

Ref: https://github.com/eslint/json/pull/259

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

I found it while working on https://github.com/eslint/json/pull/259.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - JSON parsing errors now report the accurate line and column where the issue occurred.

- **Tests**
  - Added coverage to verify error locations for invalid comments and trailing commas in JSON and JSONC modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->